### PR TITLE
Improve Windows compatibility for npm run analyze

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build && node ./scripts/generate-sitemap",
     "serve": "next start",
-    "analyze": "ANALYZE=true next build"
+    "analyze": "env ANALYZE=true next build"
   },
   "dependencies": {
     "@mapbox/rehype-prism": "^0.5.0",


### PR DESCRIPTION
Adding "env" before setting environmental variables makes it cross-platform (i.e. work on Windows in addition to Unix / Mac).

Tested Windows 10 x64

"@infinity @jamie-penney env NODE_ENV=test mocha --reporter spec will use the declared environment variable in a natively cross platform fashion, but the key is it is used by npm in an ad hoc and one-time fashion, just for the npm script execution. (It's not set or exported for future reference.) As long as you're running your command from the npm script, there's no issue. Also, the "&&" must be removed when doing it this way. – estaples Apr 5 '18 at 16:10 " Source: https://stackoverflow.com/a/27090755