### PR TITLE
Remove experimental flag modern: true

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,9 +4,6 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 
 module.exports = withBundleAnalyzer({
   pageExtensions: ['js', 'jsx', 'md', 'mdx'],
-  experimental: {
-    modern: true,
-  },
   webpack: (config, { dev, isServer }) => {
     config.module.rules.push({
       test: /\.(png|jpe?g|gif|mp4)$/i,


### PR DESCRIPTION
This feature got dropped by Next.js so should be removed, see: https://github.com/vercel/next.js/pull/19275

Arguably, it could still be worth keeping (people mention 3-6% bundle size improvement, 21% bundle size improvement when using Preact), but it's a bit of a landmine.

I haven't actually compared bundle sizes or looked at the effect of this change. What do you think @timlrx?

As discussed in that pull request over at Next.js, it's incompatible for when they migrate to Webpack 5. I think removing this feature is currently in the /canary version of Next.js, not a released version.