### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*		text eol=lf


### PR DESCRIPTION
> There once was a man from Nantucket,
> who developed on a Macintosh bucket.
> He set up his ESLint to flag Prettier errors,
> And Windows developers got CR* terrors.
> The man was no fan, so he hatched up a plan:
> He would ask Git to enforce LF** characters.
> So now developers rejoice, because of his choice:
> They can keep their Windows kit, not chuck it.

*Carriage Return, **Line Feed

Original poetry! Boom 💥

`eslintrc.js`
```
module.exports = {
  ...
  extends: [
    'plugin:prettier/recommended',
  ],
  rules: {
    'prettier/prettier': 'error',
  }
}
```

See discussion https://github.com/tailwindlabs/tailwindcss/pull/3760