### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,202 @@
-*		text eol=lf
+## Source: https://github.com/alexkaratarakis/gitattributes
+## Modified * text=auto to * text eol=lf to force LF endings.
+
+## GITATTRIBUTES FOR WEB PROJECTS
+#
+# These settings are for any web project.
+#
+# Details per file setting:
+#   text    These files should be normalized (i.e. convert CRLF to LF).
+#   binary  These files are binary and should be left untouched.
+#
+# Note that binary is a macro for -text -diff.
+######################################################################
+
+# Auto detect
+##   Force LF line endings automatically for files detected as
+##   text and leave all files detected as binary untouched.
+##   This will handle all files NOT defined below.
+*                 text eol=lf
+
+# Source code
+*.bash            text eol=lf
+*.bat             text eol=crlf
+*.cmd             text eol=crlf
+*.coffee          text
+*.css             text
+*.htm             text diff=html
+*.html            text diff=html
+*.inc             text
+*.ini             text
+*.js              text
+*.json            text
+*.jsx             text
+*.less            text
+*.ls              text
+*.map             text -diff
+*.od              text
+*.onlydata        text
+*.php             text diff=php
+*.pl              text
+*.ps1             text eol=crlf
+*.py              text diff=python
+*.rb              text diff=ruby
+*.sass            text
+*.scm             text
+*.scss            text diff=css
+*.sh              text eol=lf
+*.sql             text
+*.styl            text
+*.tag             text
+*.ts              text
+*.tsx             text
+*.xml             text
+*.xhtml           text diff=html
+
+# Docker
+Dockerfile        text
+
+# Documentation
+*.ipynb           text
+*.markdown        text
+*.md              text
+*.mdwn            text
+*.mdown           text
+*.mkd             text
+*.mkdn            text
+*.mdtxt           text
+*.mdtext          text
+*.txt             text
+AUTHORS           text
+CHANGELOG         text
+CHANGES           text
+CONTRIBUTING      text
+COPYING           text
+copyright         text
+*COPYRIGHT*       text
+INSTALL           text
+license           text
+LICENSE           text
+NEWS              text
+readme            text
+*README*          text
+TODO              text
+
+# Templates
+*.dot             text
+*.ejs             text
+*.haml            text
+*.handlebars      text
+*.hbs             text
+*.hbt             text
+*.jade            text
+*.latte           text
+*.mustache        text
+*.njk             text
+*.phtml           text
+*.tmpl            text
+*.tpl             text
+*.twig            text
+*.vue             text
+
+# Configs
+*.cnf             text
+*.conf            text
+*.config          text
+.editorconfig     text
+.env              text
+.gitattributes    text
+.gitconfig        text
+.htaccess         text
+*.lock            text -diff
+package-lock.json text -diff
+*.toml            text
+*.yaml            text
+*.yml             text
+browserslist      text
+Makefile          text
+makefile          text
+
+# Heroku
+Procfile          text
+
+# Graphics
+*.ai              binary
+*.bmp             binary
+*.eps             binary
+*.gif             binary
+*.gifv            binary
+*.ico             binary
+*.jng             binary
+*.jp2             binary
+*.jpg             binary
+*.jpeg            binary
+*.jpx             binary
+*.jxr             binary
+*.pdf             binary
+*.png             binary
+*.psb             binary
+*.psd             binary
+# SVG treated as an asset (binary) by default.
+*.svg             text
+# If you want to treat it as binary,
+# use the following line instead.
+# *.svg           binary
+*.svgz            binary
+*.tif             binary
+*.tiff            binary
+*.wbmp            binary
+*.webp            binary
+
+# Audio
+*.kar             binary
+*.m4a             binary
+*.mid             binary
+*.midi            binary
+*.mp3             binary
+*.ogg             binary
+*.ra              binary
+
+# Video
+*.3gpp            binary
+*.3gp             binary
+*.as              binary
+*.asf             binary
+*.asx             binary
+*.fla             binary
+*.flv             binary
+*.m4v             binary
+*.mng             binary
+*.mov             binary
+*.mp4             binary
+*.mpeg            binary
+*.mpg             binary
+*.ogv             binary
+*.swc             binary
+*.swf             binary
+*.webm            binary
+
+# Archives
+*.7z              binary
+*.gz              binary
+*.jar             binary
+*.rar             binary
+*.tar             binary
+*.zip             binary
+
+# Fonts
+*.ttf             binary
+*.eot             binary
+*.otf             binary
+*.woff            binary
+*.woff2           binary
+
+# Executables
+*.exe             binary
+*.pyc             binary
+
+# RC files (like .babelrc or .eslintrc)
+*.*rc             text
+
+# Ignore files (like .npmignore or .gitignore)
+*.*ignore         text


### PR DESCRIPTION
> There once was a man from Nantucket,
> who developed on a Macintosh bucket.
> He set up his ESLint to flag Prettier errors,
> And Windows developers got CR* terrors.
> The man was no fan, so he hatched up a plan:
> He would ask Git to enforce LF** characters.
> So now developers rejoice, because of his choice:
> They can keep their Windows kit, not chuck it.

*Carriage Return, **Line Feed

Original poetry! Boom 💥

`eslintrc.js`
```
module.exports = {
  ...
  extends: [
    'plugin:prettier/recommended',
  ],
  rules: {
    'prettier/prettier': 'error',
  }
}
```

See discussion https://github.com/tailwindlabs/tailwindcss/pull/3760

---

# New `.gitattributes` file

I updated the `.gitattributes` file to explicitly avoid changing binary files, based on best practices from https://gitattributes.io/

```
## Source: https://github.com/alexkaratarakis/gitattributes
## Modified * text=auto to * text eol=lf to force LF endings.

## GITATTRIBUTES FOR WEB PROJECTS
#
# These settings are for any web project.
#
# Details per file setting:
#   text    These files should be normalized (i.e. convert CRLF to LF).
#   binary  These files are binary and should be left untouched.
#
# Note that binary is a macro for -text -diff.
######################################################################

# Auto detect
##   Force LF line endings automatically for files detected as
##   text and leave all files detected as binary untouched.
##   This will handle all files NOT defined below.
*                 text eol=lf
```

The new `.gitattributes` file continues on for about 200 lines total while achieving the same result:

*Windows developers will have LF line endings for text files, meaning they will not see ESLint "prettier/prettier" errors.*

This improved `.gitattributes` file prevents corrupting binary files (e.g. `.png` or `.woff`), which can happen if git finds a false "CRLF" inside their binary code. Just ask my Vercel deploy about that 😄

### Comparison with previous `.gitattributes` file

Compared to the default `* text=auto` setting, which results in Windows users checking out text files with CRLF line endings, the `* text eol=lf` setting results in LF line endings on Windows (the desired behavior per `eslintrc.json`).

However, a one-line `.gitattributes` file that only includes `* text eol=lf` tells git to treat all files as text, which can corrupt committed binary files.

Since there's no "auto" mode, it's left to the owner of the git repo to explicitly specify every possible non-text file -- which is why the best practice around line endings is to use a `.gitattributes` file specific for your type of project.

This updated `.gitattributes` file is a slightly modified version of the open-source, community-maintained "Web Project" `.gitattributes` file by @alexkaratarkis from @alexkaratarakis/gitattributes ... Thank you to the contributors.

### Further Reading / References
1. https://gitattributes.io/ and https://github.com/alexkaratarakis/gitattributes
2. https://www.edwardthomson.com/blog/advent_day_1_gitattributes_for_text_files.html
3. https://markoskon.com/line-endings-in-vscode-with-git-and-eslint/