### PR TITLE
Fix a typo in ListLayout and PostLayout

### DIFF
--- a/layouts/ListLayout.js
+++ b/layouts/ListLayout.js
@@ -1,6 +1,6 @@
 import Link from '@/components/Link'
 import Tag from '@/components/Tag'
-import siteMetdata from '@/data/siteMetadata'
+import siteMetadata from '@/data/siteMetadata'
 import { useState } from 'react'
 
 const postDateTemplate = { year: 'numeric', month: 'long', day: 'numeric' }
@@ -54,7 +54,7 @@ export default function ListLayout({ posts, title }) {
                     <dt className="sr-only">Published on</dt>
                     <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
                       <time dateTime={date}>
-                        {new Date(date).toLocaleDateString(siteMetdata.locale, postDateTemplate)}
+                        {new Date(date).toLocaleDateString(siteMetadata.locale, postDateTemplate)}
                       </time>
                     </dd>
                   </dl>

--- a/layouts/PostLayout.js
+++ b/layouts/PostLayout.js
@@ -3,11 +3,11 @@ import PageTitle from '@/components/PageTitle'
 import SectionContainer from '@/components/SectionContainer'
 import { BlogSeo } from '@/components/SEO'
 import Tag from '@/components/Tag'
-import siteMetdata from '@/data/siteMetadata'
+import siteMetadata from '@/data/siteMetadata'
 
-const editUrl = (fileName) => `${siteMetdata.siteRepo}/blob/master/data/blog/${fileName}`
+const editUrl = (fileName) => `${siteMetadata.siteRepo}/blob/master/data/blog/${fileName}`
 const discussUrl = (slug) =>
-  `https://mobile.twitter.com/search?q=${encodeURIComponent(`${siteMetdata.siteUrl}/blog/${slug}`)}`
+  `https://mobile.twitter.com/search?q=${encodeURIComponent(`${siteMetadata.siteUrl}/blog/${slug}`)}`
 
 const postDateTemplate = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
 
@@ -16,7 +16,7 @@ export default function PostLayout({ children, frontMatter, next, prev }) {
 
   return (
     <SectionContainer>
-      <BlogSeo url={`${siteMetdata.siteUrl}/blog/${frontMatter.slug}`} {...frontMatter} />
+      <BlogSeo url={`${siteMetadata.siteUrl}/blog/${frontMatter.slug}`} {...frontMatter} />
       <article>
         <div className="xl:divide-y xl:divide-gray-200 xl:dark:divide-gray-700">
           <header className="pt-6 xl:pb-6">
@@ -26,7 +26,7 @@ export default function PostLayout({ children, frontMatter, next, prev }) {
                   <dt className="sr-only">Published on</dt>
                   <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
                     <time dateTime={date}>
-                      {new Date(date).toLocaleDateString(siteMetdata.locale, postDateTemplate)}
+                      {new Date(date).toLocaleDateString(siteMetadata.locale, postDateTemplate)}
                     </time>
                   </dd>
                 </div>
@@ -45,17 +45,17 @@ export default function PostLayout({ children, frontMatter, next, prev }) {
               <dd>
                 <ul className="flex justify-center space-x-8 xl:block sm:space-x-12 xl:space-x-0 xl:space-y-8">
                   <li className="flex items-center space-x-2">
-                    <img src={siteMetdata.image} alt="avatar" className="w-10 h-10 rounded-full" />
+                    <img src={siteMetadata.image} alt="avatar" className="w-10 h-10 rounded-full" />
                     <dl className="text-sm font-medium leading-5 whitespace-nowrap">
                       <dt className="sr-only">Name</dt>
-                      <dd className="text-gray-900 dark:text-gray-100">{siteMetdata.author}</dd>
+                      <dd className="text-gray-900 dark:text-gray-100">{siteMetadata.author}</dd>
                       <dt className="sr-only">Twitter</dt>
                       <dd>
                         <Link
-                          href={siteMetdata.twitter}
+                          href={siteMetadata.twitter}
                           className="text-blue-500 hover:text-blue-600 dark:hover:text-blue-400"
                         >
-                          {siteMetdata.twitter.replace('https://twitter.com/', '@')}
+                          {siteMetadata.twitter.replace('https://twitter.com/', '@')}
                         </Link>
                       </dd>
                     </dl>


### PR DESCRIPTION
This pull request fix a typo in ListLayout and PostLayout: `siteMetdata` -> `siteMetadata`