### PR TITLE
Add convertStringToHTML function to prevent RSS encoding issues

### DIFF
--- a/lib/generate-rss.js
+++ b/lib/generate-rss.js
@@ -1,11 +1,14 @@
 import siteMetadata from '@/data/siteMetadata'
 
+const convertStringToHTML = (string) =>
+  string.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;').replace(/"/g, '&quot;')
+
 const generateRssItem = (post) => `
   <item>
     <guid>${siteMetadata.siteUrl}/blog/${post.slug}</guid>
-    <title>${post.title}</title>
+    <title>${convertStringToHTML(post.title)}</title>
     <link>${siteMetadata.siteUrl}/blog/${post.slug}</link>
-    <description>${post.summary}</description>
+    <description>${convertStringToHTML(post.summary)}</description>
     <pubDate>${new Date(post.date).toUTCString()}</pubDate>
     <author>${siteMetadata.email} (${siteMetadata.author})</author>
     ${post.tags.map((t) => `<category>${t}</category>`).join('')}
@@ -15,9 +18,9 @@ const generateRssItem = (post) => `
 const generateRss = (posts, page = 'index.xml') => `
   <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
-      <title>${siteMetadata.title}</title>
+      <title>${convertStringToHTML(siteMetadata.title)}</title>
       <link>${siteMetadata.siteUrl}/blog</link>
-      <description>${siteMetadata.description}</description>
+      <description>${convertStringToHTML(siteMetadata.description)}</description>
       <language>${siteMetadata.language}</language>
       <managingEditor>${siteMetadata.email} (${siteMetadata.author})</managingEditor>
       <webMaster>${siteMetadata.email} (${siteMetadata.author})</webMaster>


### PR DESCRIPTION
When parsing descriptions and titles with characters like '&', '<', etc. feed was broken. This regex swaps these characters with their HTML entity equivalent.