### PR TITLE
Remove Unexpected File

### DIFF
--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -98,6 +98,10 @@ export async function getAllFilesFrontMatter(folder) {
   files.forEach((file) => {
     // Replace is needed to work on Windows
     const fileName = file.slice(prefixPaths.length + 1).replace(/\\/g, '/')
+    // Remove Unexpected File
+    if (path.extname(fileName) !== '.md' && path.extname(fileName) !== '.mdx') {
+        return
+    }
     const source = fs.readFileSync(file, 'utf8')
     const { data } = matter(source)
     if (data.draft !== true) {


### PR DESCRIPTION
If there is an unexpected file error, eg `.DS_Store` common in macOS

I'm a beginner, but this works 😊


```
TypeError: Cannot read property 'join' of undefined
    at eval (webpack-internal:///./layouts/ListLayout.js:37:86)
    at Array.filter (<anonymous>)
    at ListLayout (webpack-internal:///./layouts/ListLayout.js:36:35)
```
```
TypeError: Cannot read property 'map' of undefined
    at eval (webpack-internal:///./pages/index.js:134:40)
    at Array.map (<anonymous>)
    at Home (webpack-internal:///./pages/index.js:72:84)
```
![image](https://user-images.githubusercontent.com/31751526/122546439-86fc0300-d061-11eb-9429-f1a70386ccfc.png)
