### PR TITLE
Fix date sort, frontmatter parsing

### DIFF
--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -35,7 +35,10 @@ export function formatSlug(slug) {
   return slug.replace(/\.(mdx|md)/, '')
 }
 
-export function dateSortDesc(a, b) {
+export function dateSortDesc(dateA, dateB) {
+  const a = Date.parse(dateA)
+  const b = Date.parse(dateB)
+
   if (a > b) return -1
   if (a < b) return 1
   return 0


### PR DESCRIPTION
Add compatibility to make it easier for others to migrate.
The date in some old files is not the Date String, it is better to use the Date object to determine it.