### PR TITLE
fix: rename `giscus-frame` class to `giscus`

### DIFF
--- a/components/comments/Giscus.js
+++ b/components/comments/Giscus.js
@@ -42,7 +42,7 @@ const Giscus = ({ mapping }) => {
   return (
     <div className="pt-6 pb-6 text-center text-gray-700 dark:text-gray-300">
       {enableLoadComments && <button onClick={LoadComments}>Load Comments</button>}
-      <div className="giscus-frame" id={COMMENTS_ID} />
+      <div className="giscus" id={COMMENTS_ID} />
     </div>
   )
 }


### PR DESCRIPTION
Fix #154.

The error:

![image](https://user-images.githubusercontent.com/6379424/127415094-2aceee66-ef69-4229-a30b-20bfab800b01.png)

It is caused by a recent update in giscus: https://github.com/laymonage/giscus/commit/ae401f85cea100381554f7a739cb7fe7a415f2b4

The update was done to prevent `iFrameResizer` from interfering with other `<iframe>` elements on the page. (I think by default it applies to all `<iframes>` that exist on the page.)

However, the error exists because you use the `giscus-frame` class for the div. The `giscus-frame` is meant to be used by giscus' `<iframe>` tag only, and it's managed by the client script. You should use the `giscus` class instead to tell giscus where to put the `<iframe>`.

From the docs:

![image](https://user-images.githubusercontent.com/6379424/127415233-b984b63f-257c-41cd-80cb-42dfc9f6d41b.png)
