### PR TITLE
chore(slug): added ssr for other locales

### DIFF
--- a/pages/blog/[...slug].js
+++ b/pages/blog/[...slug].js
@@ -1,5 +1,4 @@
 import fs from 'fs'
-import { useRouter } from 'next/router'
 import PageTitle from '@/components/PageTitle'
 import generateRss from '@/lib/generate-rss'
 import { MDXLayoutRenderer } from '@/components/MDXComponents'
@@ -21,10 +20,10 @@ export async function getStaticPaths({ locales }) {
     paths: localesPost.map(([p, l]) => ({
       params: {
         slug: formatSlug(p).split('/'),
-        locale: l,
       },
+      locale: l,
     })),
-    fallback: true,
+    fallback: false,
   }
 }
 
@@ -50,12 +49,6 @@ export async function getStaticProps({ locale, params }) {
 }
 
 export default function Blog({ post, authorDetails, prev, next }) {
-  const router = useRouter()
-
-  if (router.isFallback) {
-    return <div>Loading...</div>
-  }
-
   const { mdxSource, frontMatter } = post
 
   return (


### PR DESCRIPTION
Hello,

I found a little something on you pr for the translation demo. 

The `locale` should be outside  `params` scope, Next js documentation is very unclear on that point. That's why you had to enable the Fallback.

(Thank you a lot for the demo ! It's going to be very useful for my own blog !)