### PR TITLE
Use `innerText` to copy code content

### DIFF
--- a/components/Pre.js
+++ b/components/Pre.js
@@ -14,7 +14,7 @@ const Pre = (props) => {
   }
   const onCopy = () => {
     setCopied(true)
-    navigator.clipboard.writeText(textInput.current.textContent)
+    navigator.clipboard.writeText(textInput.current.innerText)
     setTimeout(() => {
       setCopied(false)
     }, 2000)


### PR DESCRIPTION
Fix #168.

The `textContent` property doesn't preserve line breaks. As a result, copying code using the button in the `<Pre>` component, e.g.

```js
theme: {
    colors: {
      primary: colors.teal,
      gray: colors.trueGray,
      ...
    }
  ...
}
```

results in the following when pasted:

```js
theme: {    colors: {      primary: colors.teal,      gray: colors.trueGray,      ...    }  ...}
```

By replacing `textContent` with `innerText`, line breaks are preserved.