### PR TITLE
fix: support all prism and refractor lang

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-nextjs-starter-blog",
-  "version": "1.0.0-canary.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7702,9 +7702,9 @@
       }
     },
     "refractor": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-4.1.0.tgz",
-      "integrity": "sha512-qUcwf/qkP3sH7RrhgEPt5d4/5M7lK9nCH8UkYXNsmXMDUd7JqGg91IQVEUS9maJqqiF4Bo02P5ozWSXOQb7jow==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-4.1.1.tgz",
+      "integrity": "sha512-9voyHtZDFp+eefstYM+ruonRfaYAUZxWOi8GCCXhz0b555qYy00qJLh3JbV5Du/vzmTpW7Tr/wvOJCVzIbHIxQ==",
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/prismjs": "^1.0.0",
@@ -7737,9 +7737,9 @@
           }
         },
         "hastscript": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.0.1.tgz",
-          "integrity": "sha512-3Nww02NdnAoLZlI4mifLRYU9jZ1PrMD+eYnnW3RGVKlRD2bW+fNTvr1KLnET/DAf8c6CMlMblXVUhXJiGIKwDA==",
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.0.2.tgz",
+          "integrity": "sha512-uA8ooUY4ipaBvKcMuPehTAB/YfFLSSzCwFSwT6ltJbocFUKH/GDHLN+tflq7lSRf9H86uOuxOFkh1KgIy3Gg2g==",
           "requires": {
             "@types/hast": "^2.0.0",
             "comma-separated-tokens": "^2.0.0",
@@ -7923,13 +7923,13 @@
       }
     },
     "rehype-prism-plus": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-0.0.2.tgz",
-      "integrity": "sha512-1qGZL7Vk9uAWJNqIz3dAHFQ/j7RkOAEN/1UNvfywSxZ/DQcHn4mnYf6teVdu2IEBnk1ScrXj8PPydXLwX8+Eog==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-0.0.4.tgz",
+      "integrity": "sha512-6QgqR1cZpaULPVea/9MHo6/M/35MWc4rEdqZVPAkb1bY2+BAqUqlvLGYjzPG5yRiRQvdJfumHzg3SkY+3fFFWA==",
       "requires": {
         "hast-util-to-string": "^1.0.4",
         "parse-numeric-range": "^1.2.0",
-        "refractor": "^4.0.0",
+        "refractor": "^4.1.1",
         "unist-util-visit": "^3.1.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-dom": "17.0.2",
     "reading-time": "1.3.0",
     "rehype-katex": "^5.0.0",
-    "rehype-prism-plus": "0.0.2",
+    "rehype-prism-plus": "0.0.4",
     "remark-autolink-headings": "6.0.1",
     "remark-footnotes": "^3.0.0",
     "remark-gfm": "^1.0.0",


### PR DESCRIPTION
Fix #173 

Updated rehype-prism-plus package to use `refractor/lib/all.js` instead of the default export `refractor/lib/common.js`. We should be able to parse all 258 languages!

![image](https://user-images.githubusercontent.com/28362229/128657453-ce3a1b60-5a4d-4316-8da7-18f1d0b0cc9f.png)
