### PR TITLE
fix: toc issue with remark-autolink-headings

### DIFF
--- a/lib/remark-toc-headings.js
+++ b/lib/remark-toc-headings.js
@@ -4,8 +4,8 @@ module.exports = function (options) {
   return (tree) =>
     visit(tree, 'heading', (node, index, parent) => {
       options.exportRef.push({
-        value: node.children[1].value,
-        url: node.children[0].url,
+        value: node.children[0].value || node.children[1].value,
+        url: node.children[0].url || node.children[1].url,
         depth: node.depth,
       })
     })


### PR DESCRIPTION
TOC won't work if `remark-autolink-headings` option `behavior` is set to `append`