### PR TITLE
fix: non-latin tags don't cause error

### DIFF
--- a/lib/utils/kebabCase.js
+++ b/lib/utils/kebabCase.js
@@ -1,8 +1,5 @@
-const kebabCase = (str) =>
-  str &&
-  str
-    .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
-    .map((x) => x.toLowerCase())
-    .join('-')
+import { slug } from 'github-slugger'
+
+const kebabCase = (str) => slug(str)
 
 export default kebabCase

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-nextjs-starter-blog",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tailwindcss/typography": "^0.4.0",
     "autoprefixer": "^10.2.5",
     "esbuild": "^0.12.15",
+    "github-slugger": "^1.3.0",
     "gray-matter": "^4.0.2",
     "image-size": "1.0.0",
     "mdx-bundler": "^6.0.1",


### PR DESCRIPTION
This MR force to use `github-slugger` for tags. This allows non-latin tags to work properly.

Closes #197 