### PR TITLE
add: email address format verification

### DIFF
--- a/components/social-icons/index.js
+++ b/components/social-icons/index.js
@@ -17,7 +17,8 @@ const components = {
 }
 
 const SocialIcon = ({ kind, href, size = 8 }) => {
-  if (!href) return null
+  if (!href || (kind === 'mail' && !/^mailto:\w+([.-]?\w+)@\w+([.-]?\w+)(.\w{2,3})+$/.test(href)))
+    return null
 
   const SocialSvg = components[kind]
 


### PR DESCRIPTION
Hi, 
I think not everyone wants to make their email address public, so I changed it. When the email address is empty or the format is wrong, the icon will not be displayed