### PR TITLE
feat: add separate stylesheet for prismjs code block theme

### DIFF
--- a/css/prism.css
+++ b/css/prism.css
@@ -1,0 +1,128 @@
+/**
+ * CSS Styles for code highlighting.
+ * Feel free to customize token styles 
+ * by copying from a prismjs compatible theme:
+ * https://github.com/PrismJS/prism-themes
+ */
+
+/* Code title styles */
+.remark-code-title {
+  @apply px-5 py-3 font-mono text-sm font-bold text-gray-200 bg-gray-700 rounded-t;
+}
+
+.remark-code-title + div > pre {
+  @apply mt-0 rounded-t-none;
+}
+
+/* Code block styles */
+.code-highlight {
+  @apply float-left min-w-full;
+}
+
+.code-line {
+  @apply block pl-4 pr-4 -mx-4 border-l-4 border-gray-800;
+}
+
+.highlight-line {
+  @apply -mx-4 bg-gray-700 bg-opacity-50 border-l-4 border-primary-500;
+}
+
+.line-number::before {
+  @apply pr-4 -ml-2 text-gray-400;
+  content: attr(line);
+}
+
+/* Token styles */
+/**
+ * MIT License
+ * Copyright (c) 2018 Sarah Drasner
+ * Sarah Drasner's[@sdras] Night Owl
+ * Ported by Sara vieria [@SaraVieira]
+ * Added by Souvik Mandal [@SimpleIndian]
+ */
+.token.comment,
+.token.prolog,
+.token.cdata {
+  color: rgb(99, 119, 119);
+  font-style: italic;
+}
+
+.token.punctuation {
+  color: rgb(199, 146, 234);
+}
+
+.namespace {
+  color: rgb(178, 204, 214);
+}
+
+.token.deleted {
+  color: rgba(239, 83, 80, 0.56);
+  font-style: italic;
+}
+
+.token.symbol,
+.token.property {
+  color: rgb(128, 203, 196);
+}
+
+.token.tag,
+.token.operator,
+.token.keyword {
+  color: rgb(127, 219, 202);
+}
+
+.token.boolean {
+  color: rgb(255, 88, 116);
+}
+
+.token.number {
+  color: rgb(247, 140, 108);
+}
+
+.token.constant,
+.token.function,
+.token.builtin,
+.token.char {
+  color: rgb(130, 170, 255);
+}
+
+.token.selector,
+.token.doctype {
+  color: rgb(199, 146, 234);
+  font-style: italic;
+}
+
+.token.attr-name,
+.token.inserted {
+  color: rgb(173, 219, 103);
+  font-style: italic;
+}
+
+.token.string,
+.token.url,
+.token.entity,
+.language-css .token.string,
+.style .token.string {
+  color: rgb(173, 219, 103);
+}
+
+.token.class-name,
+.token.atrule,
+.token.attr-value {
+  color: rgb(255, 203, 139);
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: rgb(214, 222, 235);
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+
+.token.italic {
+  font-style: italic;
+}

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -2,33 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
-.remark-code-title {
-  @apply px-5 py-3 font-mono text-sm font-bold text-gray-200 bg-gray-700 rounded-t;
-}
-
-.remark-code-title + div > pre {
-  @apply mt-0 rounded-t-none;
-}
-
 .task-list-item:before {
   @apply hidden;
-}
-
-.code-highlight {
-  @apply float-left min-w-full;
-}
-
-.code-line {
-  @apply block pl-4 pr-4 -mx-4 border-l-4 border-gray-800;
-}
-
-.highlight-line {
-  @apply -mx-4 bg-gray-700 bg-opacity-50 border-l-4 border-primary-500;
-}
-
-.line-number::before {
-  @apply pr-4 -ml-2 text-gray-400;
-  content: attr(line);
 }
 
 html {

--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -20,20 +20,6 @@ import rehypePrismPlus from 'rehype-prism-plus'
 
 const root = process.cwd()
 
-const tokenClassNames = {
-  tag: 'text-code-red',
-  'attr-name': 'text-code-yellow',
-  'attr-value': 'text-code-green',
-  deleted: 'text-code-red',
-  inserted: 'text-code-green',
-  punctuation: 'text-code-white',
-  keyword: 'text-code-purple',
-  string: 'text-code-green',
-  function: 'text-code-blue',
-  boolean: 'text-code-red',
-  comment: 'text-gray-400 italic',
-}
-
 export function getFiles(type) {
   const prefixPaths = path.join(root, 'data', type)
   const files = getAllFilesRecursively(prefixPaths)
@@ -100,16 +86,6 @@ export async function getFileBySlug(type, slug) {
         rehypeAutolinkHeadings,
         rehypeKatex,
         [rehypePrismPlus, { ignoreMissing: true }],
-        () => {
-          return (tree) => {
-            visit(tree, 'element', (node, index, parent) => {
-              let [token, type] = node.properties.className || []
-              if (token === 'token') {
-                node.properties.className = [tokenClassNames[type]]
-              }
-            })
-          }
-        },
       ]
       return options
     },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,5 @@
 import '@/css/tailwind.css'
+import '@/css/prism.css'
 
 import { ThemeProvider } from 'next-themes'
 import Head from 'next/head'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,14 +22,6 @@ module.exports = {
       colors: {
         primary: colors.teal,
         gray: colors.trueGray,
-        code: {
-          green: '#b5f4a5',
-          yellow: '#ffe484',
-          purple: '#d9a9ff',
-          red: '#ff8383',
-          blue: '#93ddfd',
-          white: '#fff',
-        },
       },
       typography: (theme) => ({
         DEFAULT: {


### PR DESCRIPTION
Rather than manually specifying styles for various tokens, this approach lets a user customize themes more easily by copying from an existing prismjs stylesheet which is readily available. The version incorporated in this template is copied from the night owl stylesheet. 

Does anyone have strong opinions about this change? On the plus side, I believe it leads to a more consistent. easier code block theming experience and easier maintainability. 

Will update the docs on this before merging.