### PR TITLE
chore: upgrade rehype-prism-plus to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7818,9 +7818,9 @@
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
     },
     "prismjs": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow=="
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
+      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg=="
     },
     "process": {
       "version": "0.11.10",
@@ -8163,15 +8163,15 @@
       }
     },
     "refractor": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-4.1.1.tgz",
-      "integrity": "sha512-9voyHtZDFp+eefstYM+ruonRfaYAUZxWOi8GCCXhz0b555qYy00qJLh3JbV5Du/vzmTpW7Tr/wvOJCVzIbHIxQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-4.2.1.tgz",
+      "integrity": "sha512-UhtiILJUJiKquZZPtPokJZAKu2a35cT6gPBXyv2FJj+3T+AC8fyUzVUvA0lyiiYNl9m2ShCW/SSDC9us/FsuvQ==",
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/prismjs": "^1.0.0",
         "hastscript": "^7.0.0",
         "parse-entities": "^3.0.0",
-        "prismjs": "~1.24.0"
+        "prismjs": "~1.25.0"
       }
     },
     "regenerate": {
@@ -8296,14 +8296,14 @@
       }
     },
     "rehype-prism-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-1.0.0.tgz",
-      "integrity": "sha512-CCMaW3n40FqBfAnl/hEyQqecRNETDTlWJ6SH6SEQhA8Fy2uJp58gK2VeYO1BOmwrliVckEliOVwt19RikRdV4A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-prism-plus/-/rehype-prism-plus-1.1.0.tgz",
+      "integrity": "sha512-Zq/zQubb1qZRlVRxixrreedNyuaCe3tQMUD6JrmXYSEzI9uxfETSZXY8lUM6pm2Dw4+NAMOgLHFiuDHUKsh4bg==",
       "requires": {
         "hast-util-to-html": "^8.0.1",
         "hast-util-to-string": "^2.0.0",
         "parse-numeric-range": "^1.3.0",
-        "refractor": "^4.1.1",
+        "refractor": "^4.2.1",
         "rehype-parse": "^8.0.2",
         "unified": "^10.1.0",
         "unist-util-filter": "^4.0.0",
@@ -9685,9 +9685,9 @@
           "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
         },
         "unist-util-visit-parents": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.0.0.tgz",
-          "integrity": "sha512-CVaLOYPM/EaFTYMytbaju3Tw4QI3DHnHFnL358FkEu0hZOzSm/hqBdVwOQDR60jF5ZzhB1tlZlRH0ll/yekZIQ==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+          "integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
           "requires": {
             "@types/unist": "^2.0.0",
             "unist-util-is": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "reading-time": "1.3.0",
     "rehype-autolink-headings": "^6.0.0",
     "rehype-katex": "^6.0.0",
-    "rehype-prism-plus": "^1.0.0",
+    "rehype-prism-plus": "^1.1.0",
     "rehype-slug": "^5.0.0",
     "remark-footnotes": "^4.0.0",
     "remark-gfm": "^2.0.0",


### PR DESCRIPTION
Remove irritating prismjs CVE advisory warning