### PR TITLE
fix: make line numbers in code block right aligned for a consistent UI

### DIFF
--- a/css/prism.css
+++ b/css/prism.css
@@ -28,7 +28,7 @@
 }
 
 .line-number::before {
-  @apply pr-4 -ml-2 text-gray-400;
+  @apply mr-4 -ml-2 text-gray-400 inline-block w-4 text-right;
   content: attr(line);
 }
 


### PR DESCRIPTION
## Before

When enabling line numbers using `showLineNumbers` in a MD code block, the line numbers were left aligned causing the code from Line 1-9 to be slightly on the left than for code from L10 onwards. 

<img width="120" alt="image" src="https://user-images.githubusercontent.com/5432911/140622027-25e0920e-d5f3-484f-a555-95bf23ea72b5.png">

## After
This PR fixes the above bug and right aligns the line numbers (following IDE conventions), and if merged code blocks will look like 

<img width="120" alt="image" src="https://user-images.githubusercontent.com/5432911/140622065-c15b9c39-ba40-4e49-b010-e5240e2fcdfa.png">

--- 
## Reasoning

This also follows the same way IDEs represent line numbers,

- VSCode:
<img width="120" alt="image" src="https://user-images.githubusercontent.com/5432911/140622079-042aa77a-d09b-40b5-98fe-011d2e50b582.png">

- WebStorm:
<img width="120" alt="image" src="https://user-images.githubusercontent.com/5432911/140622087-b8f2ec6b-7845-4ddc-adc1-d5bf2344458f.png">
