### PR TITLE
fix: parse inline code headings to string

### DIFF
--- a/lib/remark-toc-headings.js
+++ b/lib/remark-toc-headings.js
@@ -1,6 +1,6 @@
 import { visit } from 'unist-util-visit'
 import { slug } from 'github-slugger'
-import { toString } from 'hast-util-to-string'
+import { toString } from 'mdast-util-to-string'
 
 export default function remarkTocHeadings(options) {
   return (tree) =>


### PR DESCRIPTION
The `toString` function in `hast-util-to-string` only works on text nodes but not inlineCode. `mdast-util-to-string` is more general and extracts the value of all nodes. Fix #278 

