### PR TITLE
Use '::' for pseudo-classes & ::marker

### DIFF
--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -2,8 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
-.task-list-item:before {
+.task-list-item::before {
   @apply hidden;
+}
+
+.task-list-item {
+  @apply list-none;
 }
 
 html {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -77,16 +77,9 @@ module.exports = {
               borderRadius: '0.25rem',
             },
             hr: { borderColor: theme('colors.gray.200') },
-            'ol li::before': {
-              fontWeight: '600',
-              color: theme('colors.gray.500'),
-            },
             'ol li::marker': {
               fontWeight: '600',
               color: theme('colors.gray.500'),
-            },
-            'ul li::before': {
-              backgroundColor: theme('colors.gray.500'),
             },
             'ul li::marker': {
               backgroundColor: theme('colors.gray.500'),
@@ -135,16 +128,9 @@ module.exports = {
               backgroundColor: theme('colors.gray.800'),
             },
             hr: { borderColor: theme('colors.gray.700') },
-            'ol li::before': {
-              fontWeight: '600',
-              color: theme('colors.gray.400'),
-            },
             'ol li::marker': {
               fontWeight: '600',
               color: theme('colors.gray.400'),
-            },
-            'ul li::before': {
-              backgroundColor: theme('colors.gray.400'),
             },
             'ul li::marker': {
               backgroundColor: theme('colors.gray.400'),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -62,10 +62,10 @@ module.exports = {
               paddingBottom: '2px',
               borderRadius: '0.25rem',
             },
-            'code:before': {
+            'code::before': {
               content: 'none',
             },
-            'code:after': {
+            'code::after': {
               content: 'none',
             },
             details: {
@@ -77,11 +77,18 @@ module.exports = {
               borderRadius: '0.25rem',
             },
             hr: { borderColor: theme('colors.gray.200') },
-            'ol li:before': {
+            'ol li::before': {
               fontWeight: '600',
               color: theme('colors.gray.500'),
             },
-            'ul li:before': {
+            'ol li::marker': {
+              fontWeight: '600',
+              color: theme('colors.gray.500'),
+            },
+            'ul li::before': {
+              backgroundColor: theme('colors.gray.500'),
+            },
+            'ul li::marker': {
               backgroundColor: theme('colors.gray.500'),
             },
             strong: { color: theme('colors.gray.600') },
@@ -128,11 +135,18 @@ module.exports = {
               backgroundColor: theme('colors.gray.800'),
             },
             hr: { borderColor: theme('colors.gray.700') },
-            'ol li:before': {
+            'ol li::before': {
               fontWeight: '600',
               color: theme('colors.gray.400'),
             },
-            'ul li:before': {
+            'ol li::marker': {
+              fontWeight: '600',
+              color: theme('colors.gray.400'),
+            },
+            'ul li::before': {
+              backgroundColor: theme('colors.gray.400'),
+            },
+            'ul li::marker': {
               backgroundColor: theme('colors.gray.400'),
             },
             strong: { color: theme('colors.gray.100') },


### PR DESCRIPTION
This pull request encompasses three closely related changes.
See the changes live here https://tailwind-nextjs-starter-blog-alexanderzeilmann.vercel.app/blog/github-markdown-guide


## `::before` instead of `:before` 
In CSS both `::before` and `:before` work, but `::before` is preferred.
Tailwind, however, accepts only the double-colon syntax, i.e. `'code:before': {content: 'none', }`
has no effect at all in `tailwind.config.js`, but `'code::before': {content: 'none', }` does.

**Changes: Replace `:before` and `:after` by `::before` and `::after`**

Rendering before the change:
![colon_before](https://user-images.githubusercontent.com/901391/146672905-f4fde055-3801-46bc-928a-f304dbd8b2bb.png)
Rendering after the change:
![colon_after](https://user-images.githubusercontent.com/901391/146672934-bd3ae9ba-cbca-4276-96cb-26576b548889.png)



## `::marker` additional to `::before` in lists in CSS
Using the `before`-pseudo element to style the list-items seems to be not working in current browsers.
The new way is using the `::marker` pseudo element.

**Changes: Add the following in `tailwind.css`**

```css
.task-list-item {
  @apply list-none;
}
```

Rendering before the change (note the gray bullet-points):
![before](https://user-images.githubusercontent.com/901391/146673535-bb8950af-f7f1-4c5d-a8c0-ae862fe79415.png)

Rendering after the change:
![after](https://user-images.githubusercontent.com/901391/146673534-edc6ae7b-ccfb-4fb7-a44e-b47242538f57.png)

## `::marker` in Tailwind
[Tailwind uses the `::marker` pseudo-element for styling lists.](https://github.com/tailwindlabs/tailwindcss-typography/blob/b3e8c22d11d549620c3b5f27e883726929a57a51/src/styles.js#L1305-L1311)

Using 
```js
'ol li::before': {
  fontWeight: '600',
  color: theme('colors.gray.500'),
},
```
in `tailwind.config.js` does not overwrite the `::marker` use by tailwind. For this we need:
```js
'ol li::marker': {
  fontWeight: '600',
  color: theme('colors.gray.500'),
},
```

**Changes: replace `ol li:before` and `ul li:before` by `ol li::marker` and `ul li::marker` in `tailwind.config.js`**


