### PR TITLE
fix: can not load external script & Unable to get disqus config of shorname

### DIFF
--- a/components/comments/Disqus.js
+++ b/components/comments/Disqus.js
@@ -16,7 +16,7 @@ const Disqus = ({ frontMatter }) => {
     }
     if (window.DISQUS === undefined) {
       const script = document.createElement('script')
-      script.src = 'https://' + siteMetadata.comment.disqus.shortname + '.disqus.com/embed.js'
+      script.src = 'https://' + siteMetadata.comment.disqusConfig.shortname + '.disqus.com/embed.js'
       script.setAttribute('data-timestamp', +new Date())
       script.setAttribute('crossorigin', 'anonymous')
       script.async = true

--- a/next.config.js
+++ b/next.config.js
@@ -5,12 +5,13 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 // You might need to insert additional domains in script-src if you are using external services
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline';
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app;
   style-src 'self' 'unsafe-inline' *.googleapis.com cdn.jsdelivr.net;
   img-src * blob: data:;
   media-src 'none';
   connect-src *;
   font-src 'self' fonts.gstatic.com cdn.jsdelivr.net;
+  frame-src giscus.app
 `
 
 const securityHeaders = [


### PR DESCRIPTION
![Screen Shot 2021-12-24 at 1 08 35 AM](https://user-images.githubusercontent.com/20951677/147275588-ab2265b4-7618-449e-a85f-77fe785af8bb.png)

1. Fix unable to load external js (Google Analytics and comment function), because Content Security Policy did not add the above to the whitelist #307 
Reproduce: https://tailwind-nextjs-starter-blog.vercel.app/blog/new-features-in-v1

2. Fix unable to get disqus config of shorname