### PR TITLE
Fix citation styles

### DIFF
--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -18,10 +18,6 @@
   @apply my-5;
 }
 
-html {
-  scroll-behavior: smooth;
-}
-
 /* https://stackoverflow.com/questions/61083813/how-to-avoid-internal-autofill-selected-style-to-be-applied */
 input:-webkit-autofill,
 input:-webkit-autofill:focus {

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -10,6 +10,14 @@
   @apply list-none;
 }
 
+.footnotes {
+  @apply pt-8 mt-12 border-t border-gray-200 dark:border-gray-700;
+}
+
+.csl-entry {
+  @apply my-5;
+}
+
 html {
   scroll-behavior: smooth;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-nextjs-starter-blog",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2004,9 +2004,9 @@
       }
     },
     "@citation-js/core": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.5.3.tgz",
-      "integrity": "sha512-FAFMzcdwFFkXxAH3VDFJQByuo+4CshPZbI2YsEtO/wJG6gSCwm6j2u+aLEjQqZlpg77+8JL+VCVMRsW9HlJjwQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.5.4.tgz",
+      "integrity": "sha512-84as1w5v24DDTlzaRUtEBWIcj5wNw9A2ELqQs2ngrbFsc1psg1FbmwJplZQDSsiJHt+MfO23+DRmtOXyn7qXsg==",
       "requires": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2",
@@ -2015,9 +2015,9 @@
       }
     },
     "@citation-js/date": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@citation-js/date/-/date-0.5.0.tgz",
-      "integrity": "sha512-oAIpoUi6I8MSWZsoe87KEx3uKGMZXA+rJFuxAa4J7fFGa8Ckz5HrdHSHOZaol0dKz+I2UZ1Fjd5kkDuprpvrDQ=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@citation-js/date/-/date-0.5.1.tgz",
+      "integrity": "sha512-1iDKAZ4ie48PVhovsOXQ+C6o55dWJloXqtznnnKy6CltJBQLIuLLuUqa8zlIvma0ZigjVjgDUhnVaNU1MErtZw=="
     },
     "@citation-js/name": {
       "version": "0.4.2",
@@ -2025,18 +2025,18 @@
       "integrity": "sha512-brSPsjs2fOVzSnARLKu0qncn6suWjHVQtrqSUrnqyaRH95r/Ad4wPF5EsoWr+Dx8HzkCGb/ogmoAzfCsqlTwTQ=="
     },
     "@citation-js/plugin-bibjson": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@citation-js/plugin-bibjson/-/plugin-bibjson-0.5.3.tgz",
-      "integrity": "sha512-ULQ5x9CJwb+OWZc9QG8C+Ch/N02onwD4xcjSVfnoR7a2tlPHk84awisd9PWyDD/VByMfXzJa3qnsegcbstsmqQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-bibjson/-/plugin-bibjson-0.5.4.tgz",
+      "integrity": "sha512-5KT7c8NOU7X2/JUgL8GmtOZFJtMFyCsLgoRBwpgDZ1pGdhE4H0/2292iPQ6SDyf2KxWAKXEy3DV5oMCqX9nzzA==",
       "requires": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2"
       }
     },
     "@citation-js/plugin-bibtex": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@citation-js/plugin-bibtex/-/plugin-bibtex-0.5.3.tgz",
-      "integrity": "sha512-lbHJODURi1bMsn4aMGv6+98jdk2fo4+1/oKhQEUjw0cUNKOLHdJQ73a/K43D01lUS2rLjwQ4LbLsh+HMJW0eHQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-bibtex/-/plugin-bibtex-0.5.4.tgz",
+      "integrity": "sha512-AxLuslvDqn3Y9ZTXXMBAVcSRgmdL5BYgA5b5ykwB/IhXSm3Y9IAX9IbcdPHi5lduowkc+HdLLXGSV/ILZNRDOw==",
       "requires": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2",
@@ -2044,35 +2044,35 @@
       }
     },
     "@citation-js/plugin-csl": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@citation-js/plugin-csl/-/plugin-csl-0.5.3.tgz",
-      "integrity": "sha512-YLatQTimAwKf2eCNIP2gDSVlyowolOLJGM4GlMl1/38vYXnouYJcpTu0xqfzBoGvm8ALzd7Uig2j/qgB1dadTQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-csl/-/plugin-csl-0.5.4.tgz",
+      "integrity": "sha512-61zCWvsmevshffkv7FyvwitSnGBWLrwRnuR6ch59pEqqx04kviiDIH40Bbc0StpRZbu0bLsESBbRCGAfC1sX/Q==",
       "requires": {
         "@citation-js/date": "^0.5.0",
         "citeproc": "^2.4.6"
       }
     },
     "@citation-js/plugin-doi": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@citation-js/plugin-doi/-/plugin-doi-0.5.3.tgz",
-      "integrity": "sha512-3k1/11hE9jrc0gQ4ByF781rATXBdgDR6HKe+YVFyuwL8egZybZk2hbDtLCSxVnfN6Kyo26BZYye+oMh0Uf4zWg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-doi/-/plugin-doi-0.5.4.tgz",
+      "integrity": "sha512-L5K58SWUYT/QFu6yOt7iB9tysSBeorX2hkE3g4rsgvayHKdmVvfmyaRoEVlxgoDRseLaReevJiYn+LOkrte9Hw==",
       "requires": {
         "@citation-js/date": "^0.5.0"
       }
     },
     "@citation-js/plugin-ris": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@citation-js/plugin-ris/-/plugin-ris-0.5.3.tgz",
-      "integrity": "sha512-a5JPrUVMllqCUqSaL08CNvmyBQtAbhYBUkXpz5iCHv/+WpPgYL0KVuZqtsmCwS+epz/5zew+GE7y4SR6IokF2Q==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-ris/-/plugin-ris-0.5.4.tgz",
+      "integrity": "sha512-oZh5AVaSSNkA1o4ZAuJ35eOQHg0OBh9zC7e4gTfmDCtku+bNuFiOt6DJhiQakofUrvyRM5k8WgnB0GHs092tDA==",
       "requires": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2"
       }
     },
     "@citation-js/plugin-wikidata": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@citation-js/plugin-wikidata/-/plugin-wikidata-0.5.3.tgz",
-      "integrity": "sha512-HP4uhsAPfxwHWIJuyHKfTcdUVkNm5VU4PYP4s+hXqJzRhFZiaYkJyvVOBPswz6h4rWusBRb1FfCjdIE5oY354A==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@citation-js/plugin-wikidata/-/plugin-wikidata-0.5.4.tgz",
+      "integrity": "sha512-3DV0j3Rk7RjRjxgyat5lFyg+Uat6jniZAJnKPV+ryWW2N5mhdksBLWqRaTCcsN/CFZ0PEnCY1eRajfIjNKuGjg==",
       "requires": {
         "@citation-js/date": "^0.5.0",
         "@citation-js/name": "^0.4.2",
@@ -3692,35 +3692,35 @@
       }
     },
     "citation-js": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/citation-js/-/citation-js-0.5.3.tgz",
-      "integrity": "sha512-QfQ9ys16JD1JnIhxwA4WgaaiSKfBWyZ0wG/BHtVRXullNPfAcR1NOzPfOe9/BYZbtWvVwQE6MyilUQ2Gr/cmgg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/citation-js/-/citation-js-0.5.4.tgz",
+      "integrity": "sha512-MS/N7uoDNOVrIwD5O0wvXuGpKVa5xWM8cCFYY80MO0K3Ts9Cf1Kk+uXJjKoRaaMG7KtVA9K1guC1wqPt/GrPEA==",
       "requires": {
-        "@citation-js/cli": "0.5.3",
-        "@citation-js/core": "0.5.3",
-        "@citation-js/date": "0.5.0",
+        "@citation-js/cli": "0.5.4",
+        "@citation-js/core": "0.5.4",
+        "@citation-js/date": "0.5.1",
         "@citation-js/name": "0.4.2",
-        "@citation-js/plugin-bibjson": "0.5.3",
-        "@citation-js/plugin-bibtex": "0.5.3",
-        "@citation-js/plugin-csl": "0.5.3",
-        "@citation-js/plugin-doi": "0.5.3",
-        "@citation-js/plugin-ris": "0.5.3",
-        "@citation-js/plugin-wikidata": "0.5.3",
+        "@citation-js/plugin-bibjson": "0.5.4",
+        "@citation-js/plugin-bibtex": "0.5.4",
+        "@citation-js/plugin-csl": "0.5.4",
+        "@citation-js/plugin-doi": "0.5.4",
+        "@citation-js/plugin-ris": "0.5.4",
+        "@citation-js/plugin-wikidata": "0.5.4",
         "citeproc": "^2.4.59"
       },
       "dependencies": {
         "@citation-js/cli": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/@citation-js/cli/-/cli-0.5.3.tgz",
-          "integrity": "sha512-m7aU1otSH4g5pybclB1wzl6RifmB1+oOmFUZ00uGraqLwfM9CcGCKFsSoubI10YZ3Gj2qccaRofRmF6xYuqKlw==",
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/@citation-js/cli/-/cli-0.5.4.tgz",
+          "integrity": "sha512-Ud1y0KrJgVaJDvDxlUaN6uqr3RNKBzJzPrK4eqZxHUkq2o7Gk1m9HAHHGPKIZNRRnoTS7MRcM1x2nTbbskUHoQ==",
           "requires": {
-            "@citation-js/core": "^0.5.3",
-            "@citation-js/plugin-bibjson": "^0.5.3",
-            "@citation-js/plugin-bibtex": "^0.5.3",
-            "@citation-js/plugin-csl": "^0.5.3",
-            "@citation-js/plugin-doi": "^0.5.3",
-            "@citation-js/plugin-ris": "^0.5.3",
-            "@citation-js/plugin-wikidata": "^0.5.3",
+            "@citation-js/core": "^0.5.4",
+            "@citation-js/plugin-bibjson": "^0.5.4",
+            "@citation-js/plugin-bibtex": "^0.5.4",
+            "@citation-js/plugin-csl": "^0.5.4",
+            "@citation-js/plugin-doi": "^0.5.4",
+            "@citation-js/plugin-ris": "^0.5.4",
+            "@citation-js/plugin-wikidata": "^0.5.4",
             "commander": "^5.1.0"
           }
         }
@@ -9287,11 +9287,11 @@
       }
     },
     "rehype-citation": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/rehype-citation/-/rehype-citation-0.1.1.tgz",
-      "integrity": "sha512-jat2DWeIYooNIdhEwEvkebACPM3kQWEKSJpR844DSZlTTodDGAQEZ4d6FGMyV8Cpm9yMQ4cEK8Nnk+JU+4HHfQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/rehype-citation/-/rehype-citation-0.1.2.tgz",
+      "integrity": "sha512-PBPIDSpaXHUoIkymjceiGbSnMv4tQkx4pMXwkBgqL4ALO07rZ3dFosVcW0QUJBtxn3S3CmuFs1iyPNEelWwcpg==",
       "requires": {
-        "citation-js": "^0.5.1",
+        "citation-js": "^0.5.4",
         "hast-util-from-parse5": "^7.1.0",
         "parse5": "^6.0.1",
         "unified": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-dom": "17.0.2",
     "reading-time": "1.3.0",
     "rehype-autolink-headings": "^6.1.0",
-    "rehype-citation": "^0.1.1",
+    "rehype-citation": "^0.1.2",
     "rehype-katex": "^6.0.2",
     "rehype-prism-plus": "^1.1.3",
     "rehype-slug": "^5.0.0",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -2,7 +2,7 @@ import Document, { Html, Head, Main, NextScript } from 'next/document'
 class MyDocument extends Document {
   render() {
     return (
-      <Html lang="en">
+      <Html lang="en" className="scroll-smooth">
         <Head>
           <link rel="apple-touch-icon" sizes="76x76" href="/static/favicons/apple-touch-icon.png" />
           <link


### PR DESCRIPTION
- Fix some style changes that were reverted when upgrading from tailwind 2.0 to 3.0, namely on the footnotes and citation spacing.

- Move smooth-scroll to HTML body as it is it is now supported in tailwind 3.0