### PR TITLE
feat: add support for umami analytics

### DIFF
--- a/components/analytics/Umami.js
+++ b/components/analytics/Umami.js
@@ -1,0 +1,18 @@
+import Script from 'next/script'
+
+import siteMetadata from '@/data/siteMetadata'
+
+const UmamiScript = () => {
+  return (
+    <>
+      <Script
+        async
+        defer
+        data-website-id={siteMetadata.analytics.umamiWebsiteId}
+        src="https://umami.example.com/umami.js" // Replace with your umami instance
+      />
+    </>
+  )
+}
+
+export default UmamiScript

--- a/components/analytics/index.js
+++ b/components/analytics/index.js
@@ -1,6 +1,7 @@
 import GA from './GoogleAnalytics'
 import Plausible from './Plausible'
 import SimpleAnalytics from './SimpleAnalytics'
+import Umami from './Umami'
 import siteMetadata from '@/data/siteMetadata'
 
 const isProduction = process.env.NODE_ENV === 'production'
@@ -10,6 +11,7 @@ const Analytics = () => {
     <>
       {isProduction && siteMetadata.analytics.plausibleDataDomain && <Plausible />}
       {isProduction && siteMetadata.analytics.simpleAnalytics && <SimpleAnalytics />}
+      {isProduction && siteMetadata.analytics.umamiWebsiteId && <Umami />}
       {isProduction && siteMetadata.analytics.googleAnalyticsId && <GA />}
     </>
   )

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -18,9 +18,10 @@ const siteMetadata = {
   linkedin: 'https://www.linkedin.com',
   locale: 'en-US',
   analytics: {
-    // supports plausible, simpleAnalytics or googleAnalytics
+    // supports plausible, simpleAnalytics, umami or googleAnalytics
     plausibleDataDomain: '', // e.g. tailwind-nextjs-starter-blog.vercel.app
     simpleAnalytics: false, // true or false
+    umamiWebsiteId: '', // e.g. 123e4567-e89b-12d3-a456-426614174000
     googleAnalyticsId: '', // e.g. UA-000000-2 or G-XXXXXXX
   },
   newsletter: {


### PR DESCRIPTION
I added support for [umami](https://umami.is) to [my blog](https://github.com/alaq/adrien.sh).

Umami is a self hosted analytics solution. I chose it because for some reason even Plausible self hosted was blocked by uBlock Origin. I figured I would offer to have the changes upstream as well.

Feel free to close this if it is not wanted.