### PR TITLE
fix: should use visibility to control display state of scroll top button

### DIFF
--- a/components/ScrollTopAndComment.js
+++ b/components/ScrollTopAndComment.js
@@ -22,12 +22,13 @@ const ScrollTopAndComment = () => {
     document.getElementById('comment').scrollIntoView()
   }
   return (
-    <div className="fixed flex-col hidden gap-3 right-8 bottom-8 md:flex">
+    <div
+      className={`fixed flex-col hidden gap-3 right-8 bottom-8 ${show ? 'md:flex' : 'md:hidden'}`}
+    >
       <button
         aria-label="Scroll To Comment"
         type="button"
         onClick={handleScrollToComment}
-        style={{ opacity: show ? 1 : 0 }}
         className="p-2 text-gray-500 transition-all bg-gray-200 rounded-full dark:text-gray-400 dark:bg-gray-700 dark:hover:bg-gray-600 hover:bg-gray-300"
       >
         <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
@@ -42,7 +43,6 @@ const ScrollTopAndComment = () => {
         aria-label="Scroll To Top"
         type="button"
         onClick={handleScrollTop}
-        style={{ opacity: show ? 1 : 0 }}
         className="p-2 text-gray-500 transition-all bg-gray-200 rounded-full dark:text-gray-400 dark:bg-gray-700 dark:hover:bg-gray-600 hover:bg-gray-300"
       >
         <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">


### PR DESCRIPTION
The current version use "opacity" to control the display state of the button, but when it is hidden, the mouse can still click on the button in the lower right corner 