### PR TITLE
chore: ability to use the 'cyrillic' alphabet

### DIFF
--- a/lib/utils/kebabCase.js
+++ b/lib/utils/kebabCase.js
@@ -1,8 +1,5 @@
-const kebabCase = (str) =>
-  str &&
-  str
-    .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
-    .map((x) => x.toLowerCase())
-    .join('-')
+import { slug } from 'github-slugger'
+
+const kebabCase = (str) => slug(str)
 
 export default kebabCase


### PR DESCRIPTION
In this variant (from the master branch), we can use the Cyrillic alphabet for the tag's name.