### PR TITLE
fix: incorrect url generated for authors pages in sitemap

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -22,6 +22,7 @@ const siteMetadata = require('../data/siteMetadata')
                 const path = page
                   .replace('pages/', '/')
                   .replace('data/blog', '/blog')
+                  .replace('data/authors', '/authors')
                   .replace('public/', '/')
                   .replace('.js', '')
                   .replace('.mdx', '')


### PR DESCRIPTION
previously the authors urls in the sitemap would be generated as
```
sitename.comdata/authors/default
```
this would make Google's SEO dashboard thrown an error since it would consider the url outside of the current submitted domain

this change fixes the issue in the same manner as how blog urls are for sitemaps. have confirmed and tested the change