### PR TITLE
refactor: missing a value for `letterSpacing`

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,9 @@ module.exports = {
   darkMode: 'class',
   theme: {
     extend: {
+      letterSpacing: {
+				tight: "-.05em",
+			},
       spacing: {
         '9/16': '56.25%',
       },


### PR DESCRIPTION
If used like this definition `letterSpacing: theme('letterSpacing.tight')`, we need to have its value or remove it from the code.