### PR TITLE
fix: hover state for a tag in prose

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,7 +29,7 @@ module.exports = {
             a: {
               color: theme('colors.primary.500'),
               '&:hover': {
-                color: theme('colors.primary.600'),
+                color: `${theme('colors.primary.600')} !important`,
               },
               code: { color: theme('colors.primary.400') },
             },
@@ -97,7 +97,7 @@ module.exports = {
             a: {
               color: theme('colors.primary.500'),
               '&:hover': {
-                color: theme('colors.primary.400'),
+                color: `${theme('colors.primary.400')} !important`,
               },
               code: { color: theme('colors.primary.400') },
             },


### PR DESCRIPTION
Added `!important` to a tag hover state for tailwind prose plugin to fix #342.

Alternatively, tailwind 3.0 supports [element modifiers](https://tailwindcss.com/docs/typography-plugin#element-modifiers) directly on prose component, but this would require refactoring the styles to the respective prose sections.