### PR TITLE
Create `data/blog` directory if missing

### DIFF
--- a/scripts/compose.js
+++ b/scripts/compose.js
@@ -101,7 +101,7 @@ inquirer
       .replace(/ /g, '-')
       .replace(/-+/g, '-')
     const frontMatter = genFrontMatter(answers)
-    if (!fs.existsSync('data/blog', { recursive: true })) fs.mkdirSync('data/blog')
+    if (!fs.existsSync('data/blog')) fs.mkdirSync('data/blog', { recursive: true })
     const filePath = `data/blog/${fileName ? fileName : 'untitled'}.${
       answers.extension ? answers.extension : 'md'
     }`

--- a/scripts/compose.js
+++ b/scripts/compose.js
@@ -101,6 +101,7 @@ inquirer
       .replace(/ /g, '-')
       .replace(/-+/g, '-')
     const frontMatter = genFrontMatter(answers)
+    if (!fs.existsSync('data/blog', { recursive: true })) fs.mkdirSync('data/blog')
     const filePath = `data/blog/${fileName ? fileName : 'untitled'}.${
       answers.extension ? answers.extension : 'md'
     }`


### PR DESCRIPTION
If for any reason the `data/blog` directory is not present, the script fails. This change creates the `data/blog` directory if it doesn't yet exist to prevent error.