### PR TITLE
fix: insert code title relative to parent

### DIFF
--- a/lib/remark-code-title.js
+++ b/lib/remark-code-title.js
@@ -2,7 +2,7 @@ import { visit } from 'unist-util-visit'
 
 export default function remarkCodeTitles() {
   return (tree) =>
-    visit(tree, 'code', (node, index) => {
+    visit(tree, 'code', (node, index, parent) => {
       const nodeLang = node.lang || ''
       let language = ''
       let title = ''
@@ -26,7 +26,7 @@ export default function remarkCodeTitles() {
         data: { _xdmExplicitJsx: true },
       }
 
-      tree.children.splice(index, 0, titleNode)
+      parent.children.splice(index, 0, titleNode)
       node.lang = language
     })
 }


### PR DESCRIPTION
Fix https://github.com/timlrx/rehype-prism-plus/issues/29

Code title should be inserted relative to the parent, not the root component as it may be a child itself e.g.

````
<div style={{height: '300px', overflow: 'scroll'}}>
```json:fileName.json
A very long code snippet
```
</div>
````