### PR TITLE
pin minor typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "socket.io-client": "^4.4.0",
     "prettier": "^2.5.1",
     "prettier-plugin-tailwindcss": "^0.1.4",
-    "typescript": "^4.3.5"
+    "typescript": "~4.3.5"
   },
   "lint-staged": {
     "*.+(js|jsx|ts|tsx)": [


### PR DESCRIPTION
Forking this repo and using a different package manager which does not respect the existing package-lock file will cause ts 4.5 to be installed, which [hangs during build](https://github.com/microsoft/TypeScript/issues/46900).