### PR TITLE
exclude preload from hsts header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -43,7 +43,7 @@ const securityHeaders = [
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
   {
     key: 'Strict-Transport-Security',
-    value: 'max-age=31536000; includeSubDomains; preload',
+    value: 'max-age=31536000; includeSubDomains',
   },
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
   {


### PR DESCRIPTION
Fix https://github.com/timlrx/tailwind-nextjs-starter-blog/issues/304#issuecomment-1036579448

I think the best way to do it would be to keep the `max-age` and `includeSubDomains` but exclude `preload` by default.
 
To quote [HSTS preload org](https://hstspreload.org/):
> If you maintain a project that provides HTTPS configuration advice or provides an option to enable HSTS, do not include the preload directive by default. We get regular emails from site operators who tried out HSTS this way, only to find themselves on the preload list by the time they find they need to remove HSTS to access certain subdomains. [Removal](https://hstspreload.org/#removal) tends to be slow and painful for those sites.

Without the preload option ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)):
>Should it be necessary to disable Strict Transport Security, setting the max-age to 0 (over an https connection) will immediately expire the Strict-Transport-Security header, allowing access via http.
