### PR TITLE
fix: remove unused loader config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -68,19 +68,6 @@ module.exports = withBundleAnalyzer({
   },
   webpack: (config, { dev, isServer }) => {
     config.module.rules.push({
-      test: /\.(png|jpe?g|gif|mp4)$/i,
-      use: [
-        {
-          loader: 'file-loader',
-          options: {
-            publicPath: '/_next',
-            name: 'static/media/[name].[hash].[ext]',
-          },
-        },
-      ],
-    })
-
-    config.module.rules.push({
       test: /\.svg$/,
       use: ['@svgr/webpack'],
     })


### PR DESCRIPTION
The existing unused loader config interferes with importing images locally with `next/image`