### PR TITLE
Render floating comment button only if a provider is specified

### DIFF
--- a/components/ScrollTopAndComment.js
+++ b/components/ScrollTopAndComment.js
@@ -1,3 +1,4 @@
+import siteMetadata from '@/data/siteMetadata'
 import { useEffect, useState } from 'react'
 import smoothscroll from 'smoothscroll-polyfill'
 
@@ -25,20 +26,22 @@ const ScrollTopAndComment = () => {
     <div
       className={`fixed right-8 bottom-8 hidden flex-col gap-3 ${show ? 'md:flex' : 'md:hidden'}`}
     >
-      <button
-        aria-label="Scroll To Comment"
-        type="button"
-        onClick={handleScrollToComment}
-        className="rounded-full bg-gray-200 p-2 text-gray-500 transition-all hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
-      >
-        <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-          <path
-            fillRule="evenodd"
-            d="M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z"
-            clipRule="evenodd"
-          />
-        </svg>
-      </button>
+      {siteMetadata.comment.provider && (
+        <button
+          aria-label="Scroll To Comment"
+          type="button"
+          onClick={handleScrollToComment}
+          className="rounded-full bg-gray-200 p-2 text-gray-500 transition-all hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
+        >
+          <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path
+              fillRule="evenodd"
+              d="M18 10c0 3.866-3.582 7-8 7a8.841 8.841 0 01-4.083-.98L2 17l1.338-3.123C2.493 12.767 2 11.434 2 10c0-3.866 3.582-7 8-7s8 3.134 8 7zM7 9H5v2h2V9zm8 0h-2v2h2V9zM9 9h2v2H9V9z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      )}
       <button
         aria-label="Scroll To Top"
         type="button"


### PR DESCRIPTION
This pull request updates the `ScrollTopAndComment.js` component to only render the comment button in cases where a comment provider is specified at `siteMetadata.comment.provider`.

Granted, the theme default is to specify a provider, but, in cases where that provider is cleared and set to an empty string, the comment button still renders but directs users to a commenting implementation that isn't rendered.