### PR TITLE
fix: remove smoothscroll-polyfill

### DIFF
--- a/components/ScrollTopAndComment.js
+++ b/components/ScrollTopAndComment.js
@@ -1,12 +1,10 @@
 import siteMetadata from '@/data/siteMetadata'
 import { useEffect, useState } from 'react'
-import smoothscroll from 'smoothscroll-polyfill'
 
 const ScrollTopAndComment = () => {
   const [show, setShow] = useState(false)
 
   useEffect(() => {
-    smoothscroll.polyfill()
     const handleWindowScroll = () => {
       if (window.scrollY > 50) setShow(true)
       else setShow(false)
@@ -17,7 +15,7 @@ const ScrollTopAndComment = () => {
   }, [])
 
   const handleScrollTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+    window.scrollTo({ top: 0 })
   }
   const handleScrollToComment = () => {
     document.getElementById('comment').scrollIntoView()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9405,11 +9405,6 @@
         }
       }
     },
-    "smoothscroll-polyfill": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
-      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
-    },
     "socket.io": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
     "sharp": "^0.28.3",
-    "smoothscroll-polyfill": "^0.4.4",
     "tailwindcss": "^3.0.23",
     "unist-util-visit": "^4.0.0"
   },


### PR DESCRIPTION
Fix #436 

We are already using the `smooth-scroll` class from tailwind and can remove the polyfill.