### PR TITLE
set viewport to fix text scaling issue in nextjs and tailwind

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -4,6 +4,7 @@ import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import { getAllFilesFrontMatter } from '@/lib/mdx'
 import formatDate from '@/lib/utils/formatDate'
+import Head from "next/head"
 
 import NewsletterForm from '@/components/NewsletterForm'
 
@@ -18,6 +19,9 @@ export async function getStaticProps() {
 export default function Home({ posts }) {
   return (
     <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+      </Head>
       <PageSEO title={siteMetadata.title} description={siteMetadata.description} />
       <div className="divide-y divide-gray-200 dark:divide-gray-700">
         <div className="space-y-2 pt-6 pb-8 md:space-y-5">


### PR DESCRIPTION
> Hmm could not find what's wrong with this. It works when I change the font size for my desktop but not for my android chrome browser. If anyone knows what is the issue, would appreciate a PR, thanks!

Solution : Add the head component and set the default viewport

```javascript
import Head from "next/head";
<Head>
  <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
</Head>
```

[link to forum discussion](https://www.reddit.com/r/tailwindcss/comments/kj146o/i_am_struggling_with_tailwinds_responsive_design/)