### PR TITLE
Fix Frontmatter 'Auto-update modified date' option

### DIFF
--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -103,6 +103,7 @@ export async function getFileBySlug(type, slug) {
       fileName: fs.existsSync(mdxPath) ? `${slug}.mdx` : `${slug}.md`,
       ...frontmatter,
       date: frontmatter.date ? new Date(frontmatter.date).toISOString() : null,
+      lastmod: frontmatter.lastmod ? new Date(frontmatter.lastmod).toISOString() : null,
     },
   }
 }
@@ -128,6 +129,7 @@ export async function getAllFilesFrontMatter(folder) {
         ...frontmatter,
         slug: formatSlug(fileName),
         date: frontmatter.date ? new Date(frontmatter.date).toISOString() : null,
+        lastmod: frontmatter.lastmod ? new Date(frontmatter.lastmod).toISOString() : null,
       })
     }
   })


### PR DESCRIPTION
Hi, i'm using [Frontmatter](https://marketplace.visualstudio.com/items?itemName=eliostruyf.vscode-front-matter) VS Code extension. When i turn on the 'Auto-update modified date' option which add a `lastmod` Date object to the mdx metadata, the app crash because `lastmod` isn't serialized.

## Metadata
```mdx
---
title: Sample .md file
date: '2016-03-08'
tags: ['markdown', 'code', 'features']
draft: false
summary: Example of a markdown file with code blocks and syntax highlighting
lastmod: 2022-05-17T09:02:22.747Z
---
```

## Error

```json
"props": {
  "pageProps": {
    "statusCode": 500
  }
},
"page": "/_error",
"query": {
  "__NEXT_PAGE": "/"
},
"buildId": "development",
"isFallback": false,
"err": {
  "name": "Error",
  "message": "Error serializing `.posts[8].lastmod` returned from `getStaticProps` in "/". Reason: `object` ("[object Date]") cannot be serialized as JSON. Please only return JSON serializable data types.",
  "stack": "Error: Error serializing `.posts[8].lastmod` returned from `getStaticProps` in "/". Reason: `object` ("[object Date]") cannot be serialized as JSON. Please only return JSON serializable data types. at isSerializable (/home/mkubdev/dev/00.opensource/tailwind-nextjs-starter-blog/node_modules/next/dist/lib/is-serializable-props.js:55:15) at /home/mkubdev/dev/00.opensource/tailwind-nextjs-starter-blog/node_modules/next/dist/lib/is-serializable-props.js:37:66 at Array.every (<anonymous>) at isSerializable (/home/mkubdev/dev/00.opensource/tailwind-nextjs-starter-blog/node_modules/next/dist/lib/is-serializable-props.js:34:39) at /home/mkubdev/dev/00.opensource/tailwind-nextjs-starter-blog/node_modules/next/dist/lib/is-serializable-props.js:47:24 at Array.every (<anonymous>) at isSerializable (/home/mkubdev/dev/00.opensource/tailwind-nextjs-starter-blog/node_modules/next/dist/lib/is-serializable-props.js:45:23) at /home/mkubdev/dev/00.opensource/tailwind-nextjs-starter-blog/node_modules/next/dist/lib/is-serializable-props.js:37:66 at Array.every (<anonymous>) at isSerializable (/home/mkubdev/dev/00.opensource/tailwind-nextjs-starter-blog/node_modules/next/dist/lib/is-serializable-props.js:34:39)"
},
"gip": true,
"scriptLoader":
```

Added a Date serialization for `lastmod` in `mdx.js` to fix the error. :)