### PR TITLE
Fix: Passing Sorted Blogs to ListLayout On [page].tsx

### DIFF
--- a/pages/blog/page/[page].tsx
+++ b/pages/blog/page/[page].tsx
@@ -23,7 +23,7 @@ export const getStaticProps = async (context) => {
   const {
     params: { page },
   } = context
-  const posts = allCoreContent(allBlogs)
+  const posts = sortedBlogPost(allBlogs)
   const pageNumber = parseInt(page as string)
   const initialDisplayPosts = posts.slice(
     POSTS_PER_PAGE * (pageNumber - 1),
@@ -36,8 +36,8 @@ export const getStaticProps = async (context) => {
 
   return {
     props: {
-      posts,
-      initialDisplayPosts,
+      initialDisplayPosts: allCoreContent(initialDisplayPosts),
+      posts: allCoreContent(posts),
       pagination,
     },
   }


### PR DESCRIPTION
Hey Tim, I've encountered a small bug which was passing the un-sorted blogs to the ListLayout on the `./blog/[page].tsx` page. I've added the `sortedBlogPost()` to `getStaticProps()` so that the sorted blog posts are passed to the ListLayout Component. 

It's my first time contributing, do let me know if this requires any further clarification. Thanks for all your hard work you've put in to bring us this template!