### PR TITLE
Fixes inconsistency in styles for divider on author and list layouts in dark mode

### DIFF
--- a/layouts/AuthorLayout.js
+++ b/layouts/AuthorLayout.js
@@ -8,7 +8,7 @@ export default function AuthorLayout({ children, frontMatter }) {
   return (
     <>
       <PageSEO title={`About - ${name}`} description={`About me - ${name}`} />
-      <div className="divide-y">
+      <div className="divide-y divide-gray-200 dark:divide-gray-700">
         <div className="space-y-2 pt-6 pb-8 md:space-y-5">
           <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
             About

--- a/layouts/ListLayout.js
+++ b/layouts/ListLayout.js
@@ -18,7 +18,7 @@ export default function ListLayout({ posts, title, initialDisplayPosts = [], pag
 
   return (
     <>
-      <div className="divide-y">
+      <div className="divide-y divide-gray-200 dark:divide-gray-700">
         <div className="space-y-2 pt-6 pb-8 md:space-y-5">
           <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
             {title}


### PR DESCRIPTION
Adds missing classes to address visual inconsistency between these elements on a few pages in dark mode.

![2022-06-09 - Screen-Shot-2022-06-09-at-10 25 36-AM](https://user-images.githubusercontent.com/445732/172908650-4b547754-41c3-4d3b-9ec2-987217df4e35.png)

![2022-06-09 - Screen-Shot-2022-06-09-at-10 25 45-AM](https://user-images.githubusercontent.com/445732/172908652-938755ff-af75-4a58-a9be-18d81d09868e.png)

