### PR TITLE
frontmatter images can now be external

### DIFF
--- a/components/SEO.js
+++ b/components/SEO.js
@@ -94,7 +94,7 @@ export const BlogSEO = ({
   const featuredImages = imagesArr.map((img) => {
     return {
       '@type': 'ImageObject',
-      url: `${siteMetadata.siteUrl}${img}`,
+      url: img.includes('http') ? img : siteMetadata.siteUrl + img,
     }
   })
 

--- a/layouts/PostLayout.js
+++ b/layouts/PostLayout.js
@@ -17,7 +17,7 @@ const discussUrl = (slug) =>
 const postDateTemplate = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
 
 export default function PostLayout({ frontMatter, authorDetails, next, prev, children }) {
-  const { slug, fileName, date, title, tags } = frontMatter
+  const { slug, fileName, date, title, images, tags } = frontMatter
 
   return (
     <SectionContainer>


### PR DESCRIPTION
BlogSEO images were hardcoded to be locally sourced only. This change performs a simple check (i.e., `http` present in URI).