### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 ## Source: https://github.com/alexkaratarakis/gitattributes
-## Modified * text=auto to * text eol=lf to force LF endings.
+## Modified * text=auto to * text=auto eol=lf to force LF endings.
 
 ## GITATTRIBUTES FOR WEB PROJECTS
 #
@@ -16,7 +16,7 @@
 ##   Force LF line endings automatically for files detected as
 ##   text and leave all files detected as binary untouched.
 ##   This will handle all files NOT defined below.
-*                 text eol=lf
+*                 text=auto eol=lf
 
 # Source code
 *.bash            text eol=lf


### PR DESCRIPTION
eg: If you have a file called `foo.wav`, the `* text eol=lf` rule will treat the file as text, and Git will automatically add the Linux ending, which will modify the source file.

Perhaps the rule should be changed to the following
```
* text=auto eol=lf
```