### PR TITLE
Modify configuration for GCP deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,9 @@ As the template uses `next/image` for image optimization, additional configurati
 
 The API routes used in the newsletter component cannot be used in a static site export. You will need to use a form API endpoint provider and substitute the route in the newsletter component accordingly. Other hosting platforms such as Netlify also offer alternative solutions - please refer to their docs for more information.
 
+**Google App Engine**
+Apart from changes mentioned above for `next/image`, configurations should be changed based on recommendations [here](https://github.com/vercel/next.js/discussions/12474#discussioncomment-17844) in order to set up the project for GAE deployment.
+
 ## Support
 
 Using the template? Support this effort by giving a star on GitHub, sharing your own blog and giving a shoutout on Twitter or becoming a project [sponsor](https://github.com/sponsors/timlrx).

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@fontsource/inter": "4.5.2",
     "@mailchimp/mailchimp_marketing": "^3.0.58",
+    "@next/bundle-analyzer": "^12.1.4",
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/typography": "^0.5.0",
     "autoprefixer": "^10.4.0",
@@ -43,7 +44,6 @@
     "unist-util-visit": "^4.0.0"
   },
   "devDependencies": {
-    "@next/bundle-analyzer": "12.1.4",
     "@svgr/webpack": "^6.1.2",
     "cross-env": "^7.0.3",
     "dedent": "^0.7.0",


### PR DESCRIPTION
## Description

The deployment to GCP uses the `gcloud app deploy` script which compiles the `next.config.js` at runtime, however the  `@next/bundle-analyzer` is a `devDependency` so the deployment stage will fail.

## Drive-by changes

Added instructions for deploying to GCP (Google App Engine) to `README.md`