### PR TITLE
fix: handle posts with missing tags

### DIFF
--- a/pages/tags/[tag].js
+++ b/pages/tags/[tag].js
@@ -26,7 +26,7 @@ export async function getStaticPaths() {
 export async function getStaticProps({ params }) {
   const allPosts = await getAllFilesFrontMatter('blog')
   const filteredPosts = allPosts.filter(
-    (post) => post.draft !== true && post.tags.map((t) => kebabCase(t)).includes(params.tag)
+    (post) => post.draft !== true && (post.tags || []).map((t) => kebabCase(t)).includes(params.tag)
   )
 
   // rss


### PR DESCRIPTION
This PR addresses an issue where the /tags page would return an error if a markdown post file was missing the `tags` field in the frontmatter. 

<img width="1008" alt="Screenshot 2023-01-24 at 06 25 10" src="https://user-images.githubusercontent.com/876900/214175721-fc4e9eb3-fbc4-47e4-87ff-a01a41239ef7.png">
