### PR TITLE
Add quotes to title and summary

### DIFF
--- a/scripts/compose.js
+++ b/scripts/compose.js
@@ -33,11 +33,11 @@ const genFrontMatter = (answers) => {
   const authorArray = answers.authors.length > 0 ? "'" + answers.authors.join("','") + "'" : ''
 
   let frontMatter = dedent`---
-  title: ${answers.title ? answers.title : 'Untitled'}
+  title: "${answers.title ? answers.title : 'Untitled'}"
   date: '${date}'
   tags: [${answers.tags ? tags : ''}]
   draft: ${answers.draft === 'yes' ? true : false}
-  summary: ${answers.summary ? answers.summary : ' '}
+  summary: "${answers.summary ? answers.summary : ' '}"
   images: []
   layout: ${answers.layout}
   canonicalUrl: ${answers.canonicalUrl}


### PR DESCRIPTION
Posts and summaries can often have punctuation that breaks markdown parsing without wrapping them in quotes