### PR TITLE
update the ContentSecurityPolicy to enable giscus css loaded.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 const ContentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app;
-  style-src 'self' 'unsafe-inline';
+  style-src 'self' 'unsafe-inline' giscus.app;
   img-src * blob: data:;
   media-src 'none';
   connect-src *;


### PR DESCRIPTION
update the ContentSecurityPolicy in `next.config.js` to enable giscus css loaded.

before:

![image](https://user-images.githubusercontent.com/31075337/225668074-29a69242-e2a2-407a-ac9f-0c636d2589dc.png)
![image](https://user-images.githubusercontent.com/31075337/225668731-4a3248ac-4337-4dd5-ac55-f8b28b7f9a7c.png)
---

after:
![image](https://user-images.githubusercontent.com/31075337/225669182-d45aeb98-6bea-4e0a-bcaa-775b2e072c33.png)
