### PR TITLE
v2 misc changes

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata({
   params: { slug: string[] }
 }): Promise<Metadata | undefined> {
   const slug = params.slug.join('/')
-  const post = allBlogs.find((p) => p.slug === slug)
+  const post = allBlogs.find((p) => encodeURIComponent(p.slug) === slug)
   const authorList = post?.authors || ['default']
   const authorDetails = authorList.map((author) => {
     const authorResults = allAuthors.find((p) => p.slug === author)
@@ -69,11 +69,12 @@ export const generateStaticParams = async () => {
 
 export default async function Page({ params }: { params: { slug: string[] } }) {
   const slug = params.slug.join('/')
+  console.log('begin generate for slug: %o', slug)
   const sortedPosts = sortedBlogPost(allBlogs) as Blog[]
-  const postIndex = sortedPosts.findIndex((p) => p.slug === slug)
+  const postIndex = sortedPosts.findIndex((p) => encodeURIComponent(p.slug) === slug)
   const prev = coreContent(sortedPosts[postIndex + 1])
   const next = coreContent(sortedPosts[postIndex - 1])
-  const post = sortedPosts.find((p) => p.slug === slug) as Blog
+  const post = sortedPosts.find((p) => encodeURIComponent(p.slug) === slug) as Blog
   const authorList = post?.authors || ['default']
   const authorDetails = authorList.map((author) => {
     const authorResults = allAuthors.find((p) => p.slug === author)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import 'css/tailwind.css'
 import 'css/prism.css'
 import 'pliny/search/algolia.css'
+import 'katex/dist/katex.css'
 
 import { Inter } from 'next/font/google'
 import { Analytics, AnalyticsConfig } from 'pliny/analytics'

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -145,7 +145,7 @@ export default makeSource({
       rehypeAutolinkHeadings,
       rehypeKatex,
       [rehypeCitation, { path: path.join(root, 'data') }],
-      [rehypePrismPlus, { defaultLanguage: 'js' }],
+      [rehypePrismPlus, { defaultLanguage: 'js', ignoreMissing: true }],
       rehypePresetMinify,
     ],
   },

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -81,7 +81,7 @@ export const Blog = defineDocumentType(() => ({
   fields: {
     title: { type: 'string', required: true },
     date: { type: 'date', required: true },
-    tags: { type: 'list', of: { type: 'string' } },
+    tags: { type: 'list', of: { type: 'string' }, default: [] },
     lastmod: { type: 'date' },
     draft: { type: 'boolean' },
     summary: { type: 'string' },

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -10,7 +10,7 @@ import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import ScrollTopAndComment from '@/components/ScrollTopAndComment'
 
-const editUrl = (path) => `${siteMetadata.siteRepo}/blob/master/data/${path}`
+const editUrl = (path) => `${siteMetadata.siteRepo}/blob/main/data/${path}`
 const discussUrl = (path) =>
   `https://mobile.twitter.com/search?q=${encodeURIComponent(`${siteMetadata.siteUrl}/${path}`)}`
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@next/bundle-analyzer": "13.4.12",
     "@tailwindcss/forms": "^0.5.4",
     "@tailwindcss/typography": "^0.5.9",
+    "@types/mdx": "^2.0.5",
     "autoprefixer": "^10.4.13",
     "contentlayer": "0.3.4",
     "esbuild": "0.18.11",


### PR DESCRIPTION
1.  chore: layouts/PostLayout.tsx use main branch for editUrl
also I sugguest this repo change from `master` to `main` branch

2. fix: import missing katex css

no katex css causing my exists formula display wrong

4. chore: tags can be empty, set default value to avoid compilation failure

my blog was migrated from other SSG to this one. and not all posts have the `tags` frontmatter.

5. fix: fix compile error for non-latin slug blog posts (I do not have this issue when I was using the very early v2 version before this pr https://github.com/timlrx/tailwind-nextjs-starter-blog/pull/658 )

6. enable ignoreMissing option for rehypePrismPlus

before pr #658 , this was enabled and it works fine for my migrated blog.

7. fix(build): add mising `@types/mdx` required by "import type { MDXComponents } from 'mdx/types'"

`next build` will fail (I am using pnpm, I do not know it effect yarn or not)
