### PR TITLE
Fix: Incorrect function name in bundleMDX's options

### DIFF
--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -60,7 +60,7 @@ export async function getFileBySlug(type, slug) {
     source,
     // mdx imports can be automatically source from the components directory
     cwd: path.join(root, 'components'),
-    xdmOptions(options, frontmatter) {
+    mdxOptions(options, frontmatter) {
       // this is the recommended way to add custom remark/rehype plugins:
       // The syntax might look weird, but it protects you in case we add/remove
       // plugins in the future.


### PR DESCRIPTION
Previously, the function name in bundleMDX was incorrectly labeled as 'xdmOptions' instead of 'mdxOptions'. 

This PR addresses the issue by modifying the function name to 'mdxOptions', ensuring accurate naming and improving code clarity.