### PR TITLE
Add missing directory to lint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env INIT_CWD=$PWD next build && cross-env NODE_OPTIONS='--experimental-json-modules' node ./scripts/postbuild.mjs",
     "serve": "next start",
     "analyze": "cross-env ANALYZE=true next build",
-    "lint": "next lint --fix --dir pages --dir components --dir lib --dir layouts --dir scripts"
+    "lint": "next lint --fix --dir pages --dir app --dir components --dir lib --dir layouts --dir scripts"
   },
   "dependencies": {
     "@next/bundle-analyzer": "13.4.12",


### PR DESCRIPTION
Add new `app` directory of next.js 13 for lint. Keeping `pages` for now as they can coexist as people upgrade