### PR TITLE
fix: error with projects is empty

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -18,15 +18,19 @@ export default function Projects() {
         </div>
         <div className="container py-12">
           <div className="-m-4 flex flex-wrap">
-            {projectsData.map((d) => (
-              <Card
-                key={d.title}
-                title={d.title}
-                description={d.description}
-                imgSrc={d.imgSrc}
-                href={d.href}
-              />
-            ))}
+            {projectsData.length > 0 ? (
+              projectsData.map((d) => (
+                <Card
+                  key={d.title}
+                  title={d.title}
+                  description={d.description}
+                  imgSrc={d.imgSrc}
+                  href={d.href}
+                />
+              ))
+            ) : (
+              <></>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
The case where `projectsData` is empty is not envisaged here

![image](https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/20951677/692994b6-2a3b-42b6-a443-bd375c733f9a)
