### PR TITLE
fix non-english tags filter failed, display error

### DIFF
--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -8,7 +8,7 @@ import { genPageMetadata } from 'app/seo'
 import { Metadata } from 'next'
 
 export async function generateMetadata({ params }: { params: { tag: string } }): Promise<Metadata> {
-  const tag = params.tag
+  const tag = decodeURI(params.tag)
   return genPageMetadata({
     title: tag,
     description: `${siteMetadata.title} ${tag} tagged content`,
@@ -31,7 +31,7 @@ export const generateStaticParams = async () => {
 }
 
 export default function TagPage({ params }: { params: { tag: string } }) {
-  const { tag } = params
+  const tag = decodeURI(params.tag)
   // Capitalize first letter and convert space to dash
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
   const filteredPosts = allCoreContent(


### PR DESCRIPTION
when tag is not English, the Tag&Blog tab can not match the right blogs, and the title of web site display not correct
<img width="1637" alt="image" src="https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/20021475/65f70daf-8099-4275-a6c1-69a7e7c2b4a2">
