### PR TITLE
fix: hardcoded check for draft in development

### DIFF
--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -35,9 +35,7 @@ export default function TagPage({ params }: { params: { tag: string } }) {
   // Capitalize first letter and convert space to dash
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
   const filteredPosts = allCoreContent(
-    allBlogs.filter(
-      (post) => post.draft !== true && post.tags && post.tags.map((t) => slug(t)).includes(tag)
-    )
+    allBlogs.filter((post) => post.tags && post.tags.map((t) => slug(t)).includes(tag))
   )
   return <ListLayout posts={filteredPosts} title={title} />
 }


### PR DESCRIPTION
`allCoreContent` checks for the draft state based on NODE_ENV which is the correct behavior. This check is redundant and is causing the tags page to skip drafts in development.