### PR TITLE
fix: include drafts in tag data during development

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -23,6 +23,7 @@ import siteMetadata from './data/siteMetadata'
 import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer.js'
 
 const root = process.cwd()
+const isProduction = process.env.NODE_ENV === 'production'
 
 const computedFields: ComputedFields = {
   readingTime: { type: 'json', resolve: (doc) => readingTime(doc.body.raw) },
@@ -47,7 +48,7 @@ const computedFields: ComputedFields = {
 function createTagCount(allBlogs) {
   const tagCount: Record<string, number> = {}
   allBlogs.forEach((file) => {
-    if (file.tags && file.draft !== true) {
+    if (file.tags && (!isProduction || file.draft !== true)) {
       file.tags.forEach((tag) => {
         const formattedTag = GithubSlugger.slug(tag)
         if (formattedTag in tagCount) {


### PR DESCRIPTION
I missed these changes in #700 
This PR will make sure that `tag-data.json` includes drafts in development.

Verified locally
![image](https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/6119839/59586518-36bc-4b90-84f8-2aef2c599ff9)
