### PR TITLE
fix: pass components in about page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,6 @@
 import { Authors, allAuthors } from 'contentlayer/generated'
 import { MDXLayoutRenderer } from 'pliny/mdx-components'
+import { components } from '@/components/MDXComponents'
 import AuthorLayout from '@/layouts/AuthorLayout'
 import { coreContent } from 'pliny/utils/contentlayer'
 import { genPageMetadata } from 'app/seo'
@@ -13,7 +14,7 @@ export default function Page() {
   return (
     <>
       <AuthorLayout content={mainContent}>
-        <MDXLayoutRenderer code={author.body.code} />
+        <MDXLayoutRenderer code={author.body.code} components={components} />
       </AuthorLayout>
     </>
   )


### PR DESCRIPTION
The MDXLayourRenderer needs to receive the `components` prop in order to render some elements correctly.

For example, external links will not be rendered with the correct anchor attributes.

## Before
![image](https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/6119839/aa92c795-d0ef-4d31-bdd2-38ef74b205fd)

## After
![image](https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/6119839/be25b539-d2f3-4ce1-9f62-022ab28a8175)
