### PR TITLE
fix: sort posts in tags page

### DIFF
--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -34,8 +34,8 @@ export default function TagPage({ params }: { params: { tag: string } }) {
   const tag = decodeURI(params.tag)
   // Capitalize first letter and convert space to dash
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
-  const filteredPosts = allCoreContent(sortPosts(
-    allBlogs.filter((post) => post.tags && post.tags.map((t) => slug(t)).includes(tag))
-  ))
+  const filteredPosts = allCoreContent(
+    sortPosts(allBlogs.filter((post) => post.tags && post.tags.map((t) => slug(t)).includes(tag)))
+  )
   return <ListLayout posts={filteredPosts} title={title} />
 }

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -1,5 +1,5 @@
 import { slug } from 'github-slugger'
-import { allCoreContent } from 'pliny/utils/contentlayer'
+import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer'
 import siteMetadata from '@/data/siteMetadata'
 import ListLayout from '@/layouts/ListLayoutWithTags'
 import { allBlogs } from 'contentlayer/generated'
@@ -34,8 +34,8 @@ export default function TagPage({ params }: { params: { tag: string } }) {
   const tag = decodeURI(params.tag)
   // Capitalize first letter and convert space to dash
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
-  const filteredPosts = allCoreContent(
+  const filteredPosts = allCoreContent(sortPosts(
     allBlogs.filter((post) => post.tags && post.tags.map((t) => slug(t)).includes(tag))
-  )
+  ))
   return <ListLayout posts={filteredPosts} title={title} />
 }


### PR DESCRIPTION
In the `/tags/<tag>` page, the posts were not sorted, so I added a `sortPosts` function call