### PR TITLE
bugfix: Fix for missing image in ld+json blob

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -86,7 +86,7 @@ export const Blog = defineDocumentType(() => ({
     lastmod: { type: 'date' },
     draft: { type: 'boolean' },
     summary: { type: 'string' },
-    images: { type: 'list', of: { type: 'string' } },
+    images: { type: 'json' },
     authors: { type: 'list', of: { type: 'string' } },
     layout: { type: 'string' },
     bibliography: { type: 'string' },


### PR DESCRIPTION
Fix for the missing image in the JSON/LD structured data.

After fix:
![image](https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/1291189/1ddb7bbc-52ae-4081-b59c-1ed633339d5f)
