### PR TITLE
fix: use sort posts for rss, fix lastBuildDate

### DIFF
--- a/scripts/rss.mjs
+++ b/scripts/rss.mjs
@@ -5,6 +5,7 @@ import { escape } from 'pliny/utils/htmlEscaper.js'
 import siteMetadata from '../data/siteMetadata.js'
 import tagData from '../app/tag-data.json' assert { type: 'json' }
 import { allBlogs } from '../.contentlayer/generated/index.mjs'
+import { sortPosts } from 'pliny/utils/contentlayer.js'
 
 const generateRssItem = (config, post) => `
   <item>
@@ -38,7 +39,7 @@ async function generateRSS(config, allBlogs, page = 'feed.xml') {
   const publishPosts = allBlogs.filter((post) => post.draft !== true)
   // RSS for blog post
   if (publishPosts.length > 0) {
-    const rss = generateRss(config, publishPosts)
+    const rss = generateRss(config, sortPosts(publishPosts))
     writeFileSync(`./public/${page}`, rss)
   }
 


### PR DESCRIPTION
as generateRSS get last build date from first post, so we need to use sorted posts, otherwise the `lastBuildDate` value is wrong