### PR TITLE
fix: filter draft posts from home & blog pages

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -8,7 +8,7 @@ const POSTS_PER_PAGE = 5
 export const metadata = genPageMetadata({ title: 'Blog' })
 
 export default function BlogPage() {
-  const posts = allCoreContent(sortPosts(allBlogs))
+  const posts = allCoreContent(sortPosts(allBlogs)).filter((b) => b?.draft !== true)
   const pageNumber = 1
   const initialDisplayPosts = posts.slice(
     POSTS_PER_PAGE * (pageNumber - 1),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { allBlogs } from 'contentlayer/generated'
 import Main from './Main'
 
 export default async function Page() {
-  const sortedPosts = sortPosts(allBlogs)
+  const sortedPosts = sortPosts(allBlogs).filter(post => post?.draft !== true)
   const posts = allCoreContent(sortedPosts)
   return <Main posts={posts} />
 }


### PR DESCRIPTION
Before this change a post with a draft status of `true` was still showing on the home and blog pages.