### PR TITLE
Accessibility improvement: match aria-label to tag text for "read more" links

### DIFF
--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -57,7 +57,7 @@ export default function Home({ posts }) {
                         <Link
                           href={`/blog/${slug}`}
                           className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                          aria-label={`Read "${title}"`}
+                          aria-label={`Read more: "${title}"`}
                         >
                           Read more &rarr;
                         </Link>


### PR DESCRIPTION
Currently when performing a [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) analysis of the [demo deployment](https://tailwind-nextjs-starter-blog.vercel.app/) of this template, the accessibility (a11y) score is 92 for both mobile and desktop with the following warnings:
* Background and foreground colors do not have a sufficient contrast ratio.
* Elements with visible text labels do not have matching accessible names.

Having the `aria-label` in the "Read More" link element of the post list item more closely match the tag's text ("Read more") increases the accessibility score to 96 for both mobile and desktop.

The color contrast warning can be fixed with different primary/secondary colors in the Tailwind configuration, but I think changing that should be up to @timlrx and/or individual users of the template.