### PR TITLE
feat: support chinese tag name

### DIFF
--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -25,7 +25,7 @@ export const generateStaticParams = async () => {
   const tagCounts = tagData as Record<string, number>
   const tagKeys = Object.keys(tagCounts)
   const paths = tagKeys.map((tag) => ({
-    tag: tag,
+    tag: encodeURI(tag),
   }))
   return paths
 }


### PR DESCRIPTION
For chinese tag name in devlopment mode will get error below:

_Error: Page "/tags/[tag]/page" is missing param "/tags/%E6%97%A5%E8%AE%B0" in "generateStaticParams()", which is required with "output: export" config._

Should be fixed with encodeURI method.