### PR TITLE
Replaced blue tailwind class with primary theme class

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -15,7 +15,7 @@ export default function NotFound() {
         <p className="mb-8">But dont worry, you can find plenty of other things on our homepage.</p>
         <Link
           href="/"
-          className="focus:shadow-outline-blue inline rounded-lg border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium leading-5 text-white shadow transition-colors duration-150 hover:bg-blue-700 focus:outline-none dark:hover:bg-blue-500"
+          className="focus:shadow-outline-primary inline rounded-lg border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium leading-5 text-white shadow transition-colors duration-150 hover:bg-primary-700 focus:outline-none dark:hover:bg-primary-500"
         >
           Back to homepage
         </Link>


### PR DESCRIPTION
I noticed the 404 page still uses the Tailwind CSS blue colour for its button.
Replaced with primary class.
