### PR TITLE
Updated file names to use .ts rather than .js

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ npx degit 'timlrx/tailwind-nextjs-starter-blog'
 3. Modify the content security policy in `next.config.js` if you want to use
    other analytics provider or a commenting solution other than giscus.
 4. Personalize `authors/default.md` (main author)
-5. Modify `projectsData.js`
-6. Modify `headerNavLinks.js` to customize navigation links
+5. Modify `projectsData.ts`
+6. Modify `headerNavLinks.ts` to customize navigation links
 7. Add blog posts
 8. Deploy on Vercel
 

--- a/data/blog/introducing-tailwind-nextjs-starter-blog.mdx
+++ b/data/blog/introducing-tailwind-nextjs-starter-blog.mdx
@@ -82,8 +82,8 @@ I wanted it to be nearly as feature-rich as popular blogging templates like [bea
 3. Modify the content security policy in `next.config.js` if you want to use
    any analytics provider or a commenting solution other than giscus.
 4. Personalize `authors/default.md` (main author)
-5. Modify `projectsData.js`
-6. Modify `headerNavLinks.js` to customize navigation links
+5. Modify `projectsData.ts`
+6. Modify `headerNavLinks.ts` to customize navigation links
 7. Add blog posts
 8. Deploy on Vercel
 


### PR DESCRIPTION
Noticed some parts of the readme an demo blog posts still ref .js files that have been renamed to .ts