### PR TITLE
docs: remove Terminals.run demo project

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Internationalization support - [Template with i18n](https://tailwind-nextjs-star
 - [hauhau.cn](https://www.hauhau.cn) - Homing's personal blog about the stuff he's learning ([source code](https://github.com/hominsu/blog))
 - [zS1m's Blog](https://contrails.space) - zS1m's personal blog for recording and sharing daily learning technical content ([source code](https://github.com/zS1m/nextjs-contrails))
 - [dariuszwozniak.net](https://dariuszwozniak.net/) - Software development blog
-- [Terminals.run](https://terminals.run) - Blog site for some thoughts and records for life and technology.
 - [markpitblado.me](https://markpitblado.me) - Mark's personal blog about the internet, privacy, and books ([source code](https://github.com/mark-pitblado/personal-website))
 
 Using the template? Feel free to create a PR and add your blog to this list.


### PR DESCRIPTION
[Terminals.run](https://terminals.run) is no longer available. Due to that it should be removed from the listed demo projects.