### PR TITLE
docs: add example of src overwriting for US umami.is tracking

### DIFF
--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -27,6 +27,9 @@ const siteMetadata = {
     umamiAnalytics: {
       // We use an env variable for this site to avoid other users cloning our analytics ID
       umamiWebsiteId: process.env.NEXT_UMAMI_ID, // e.g. 123e4567-e89b-12d3-a456-426614174000
+      // You may also need to overwrite the script if you're storing data in the US - ex:
+      // src: 'https://us.umami.is/script.js'
+      // Remember to add 'us.umami.is' in `next.config.js` as a permitted domain for the CSP
     },
     // plausibleAnalytics: {
     //   plausibleDataDomain: '', // e.g. tailwind-nextjs-starter-blog.vercel.app


### PR DESCRIPTION
### Context

Choosing to store Umami tracking data in the US (instead of the EU, which may have been the historic default) actually requires loading a different script and setting a different CSP header (since the data instead goes to `us.umami.is` instead of `analytics.umami.is`).

I wasn't able to tell this without a little poking around and pestering folks on Discord / reading of https://github.com/timlrx/pliny to realize there was an option to do so.

Discord thread: https://discord.com/channels/951898446804172840/1195052582645801010/1195055451285504040

I'm happy to tweak the language or make other updates, but this at least would give someone a thread to pull on. I spent a fair amount of time trying to figure out what could be going wrong since Umami handles the (misdirected) tracking requests fine (responds with 200 for the `send` call), but then no data ends up populating in the dashboard.