### PR TITLE
fix: update comments component incase of no provider

### DIFF
--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -5,16 +5,18 @@ import { useState } from 'react'
 import siteMetadata from '@/data/siteMetadata'
 
 export default function Comments({ slug }: { slug: string }) {
-  const [loadComments, setLoadComments] = useState(false);
-  
+  const [loadComments, setLoadComments] = useState(false)
+
   if (!siteMetadata.comments?.provider) {
-    return null;
+    return null
   }
   return (
+    <>
       {loadComments ? (
         <CommentsComponent commentsConfig={siteMetadata.comments} slug={slug} />
-      ) :
-        (<button onClick={() => setLoadComments(true)}>Load Comments</button>)
-      }
+      ) : (
+        <button onClick={() => setLoadComments(true)}>Load Comments</button>
+      )}
+    </>
   )
 }

--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -5,13 +5,16 @@ import { useState } from 'react'
 import siteMetadata from '@/data/siteMetadata'
 
 export default function Comments({ slug }: { slug: string }) {
-  const [loadComments, setLoadComments] = useState(false)
+  const [loadComments, setLoadComments] = useState(false);
+  
+  if (!siteMetadata.comments?.provider) {
+    return null;
+  }
   return (
-    <>
-      {!loadComments && <button onClick={() => setLoadComments(true)}>Load Comments</button>}
-      {siteMetadata.comments && loadComments && (
+      {loadComments ? (
         <CommentsComponent commentsConfig={siteMetadata.comments} slug={slug} />
-      )}
-    </>
+      ) :
+        (<button onClick={() => setLoadComments(true)}>Load Comments</button>)
+      }
   )
 }


### PR DESCRIPTION
Incase if someone does not have any commenting platform enabled, the code will still show the Load Comments button.
This PR fixes it and only shows the Load Comments button if a commenting platform is provided.