### PR TITLE
Add quick links where to find EmailOctopus API key and List ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,8 @@ KLAVIYO_LIST_ID=
 
 REVUE_API_KEY=
 
+# Create EmailOctopus API key at https://emailoctopus.com/api-documentation
 EMAILOCTOPUS_API_KEY=
+# List ID can be found in the URL as a UUID after clicking a list on https://emailoctopus.com/lists
+# or the settings page of your list https://emailoctopus.com/lists/{UUID}/settings
 EMAILOCTOPUS_LIST_ID=


### PR DESCRIPTION
Just a minor update to the .env.example file to point the user to where the API Key and List ID are.  Not that it was difficult to find, but I figured I'd make it even quicker.