### PR TITLE
feat: Add .editorconfig to ensure consistent line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# Editor configuration, see http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Add .editorconfig to ensure consistent line endings

This commit introduces an .editorconfig file at the root of the project to enforce consistent line endings across different operating systems and editors. It specifies LF (Unix-style) line endings for all files, ensuring a uniform development environment and preventing line-ending discrepancies that can lead to linting errors and merge conflicts. This change aims to enhance cross-platform compatibility and developer collaboration.