### PR TITLE
Fix: Don't need to encode tags when production

### DIFF
--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -25,7 +25,7 @@ export const generateStaticParams = async () => {
   const tagCounts = tagData as Record<string, number>
   const tagKeys = Object.keys(tagCounts)
   const paths = tagKeys.map((tag) => ({
-    tag: encodeURI(tag),
+    tag: process.env.NODE_ENV === 'production' ? tag : encodeURI(tag),
   }))
   return paths
 }


### PR DESCRIPTION
The tags with Chinese character would be double encoded when deploy in the way of static export. Then the server wold not  find the correct route.