### PR TITLE
chore: fix typo (wrong path)

### DIFF
--- a/data/blog/guide-to-using-images-in-nextjs.mdx
+++ b/data/blog/guide-to-using-images-in-nextjs.mdx
@@ -33,7 +33,7 @@ export default Home
 
 For a markdown file, the default image tag can be used and the default `img` tag gets replaced by the `Image` component in the build process.
 
-Assuming we have a file called `ocean.jpg` in `data/img/ocean.jpg`, the following line of code would generate the optimized image.
+Assuming we have a file called `ocean.jpg` in `static/images/ocean.jpg`, the following line of code would generate the optimized image.
 
 ```
 ![ocean](/static/images/ocean.jpg)


### PR DESCRIPTION
`data/img/ocean.jpg` appears to be unused throughout the project. All references are currently  `/static/images/ocean.jpg`. 