### PR TITLE
add JoshHaines.com blog reference for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Internationalization support - [Template with i18n](https://tailwind-nextjs-star
 - [Wujie's Blog: 旅行者计划](https://www.wujieli.com/) - Wujie's personal digital garden ([source code](https://github.com/wujieli0207/wujie-blog-next))
 - [Xiaodong's Blog](https://blog.linxiaodong.com) - Xiaodong's personal blog about front-end technology, and life. 「中文」([source code](https://github.com/buxuku/buxuku.github.io))
 - [Azurtelier.com](https://www.azurtelier.com/) - Amos's personal website for tech, music, AI illustrations, etc. [English/中文] ([Source code](https://github.com/AmosChenZixuan/Azurtelier.com))
+- [JoshHaines.com](https://www.JoshHaines.com/) - Personal website for Josh Haines.  ([source code](https://github.com/jdhaines/joshhaines))
 
 Using the template? Feel free to create a PR and add your blog to this list.
 


### PR DESCRIPTION
Hi there!  Just adding my personal website link to the list of v2 sites.  Love the template and really appreciate all your hard work.

Related to #849, I have this working using `remark-github-blockquote-alert`.  I appreciate getting this added in officially though.  GitHub's alerts are great.  You can see an example [here](https://www.joshhaines.com/blog/book-shelf/xlr8) of my implementation.