### PR TITLE
feat: Add hover highlight classes to nav links, MobileNav

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -32,7 +32,8 @@ const Header = () => {
             <Link
               key={link.title}
               href={link.href}
-              className="hidden font-medium text-gray-900 dark:text-gray-100 sm:block"
+              className="hidden font-medium text-gray-900 hover:text-primary-500 dark:text-gray-100 dark:hover:text-primary-400
+              sm:block"
             >
               {link.title}
             </Link>

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -26,7 +26,8 @@ const MobileNav = () => {
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
           fill="currentColor"
-          className="h-8 w-8 text-gray-900 dark:text-gray-100"
+          className="h-8 w-8 text-gray-900 hover:text-primary-500 dark:text-gray-100
+          dark:hover:text-primary-400"
         >
           <path
             fillRule="evenodd"
@@ -46,7 +47,8 @@ const MobileNav = () => {
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 20 20"
               fill="currentColor"
-              className="text-gray-900 dark:text-gray-100"
+              className="text-gray-900 hover:text-primary-500 dark:text-gray-100
+              dark:hover:text-primary-400"
             >
               <path
                 fillRule="evenodd"
@@ -61,7 +63,8 @@ const MobileNav = () => {
             <div key={link.title} className="px-12 py-4">
               <Link
                 href={link.href}
-                className="text-2xl font-bold tracking-widest text-gray-900 dark:text-gray-100"
+                className="text-2xl font-bold tracking-widest text-gray-900 hover:text-primary-500 dark:text-gray-100
+                dark:hover:text-primary-400"
                 onClick={onToggleNav}
               >
                 {link.title}

--- a/components/SearchButton.tsx
+++ b/components/SearchButton.tsx
@@ -18,7 +18,8 @@ const SearchButton = () => {
           viewBox="0 0 24 24"
           strokeWidth={1.5}
           stroke="currentColor"
-          className="h-6 w-6 text-gray-900 dark:text-gray-100"
+          className="h-6 w-6 text-gray-900 hover:text-primary-500 dark:text-gray-100
+          dark:hover:text-primary-400"
         >
           <path
             strokeLinecap="round"

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -9,7 +9,7 @@ const Sun = () => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 20 20"
     fill="currentColor"
-    className="h-6 w-6 text-gray-900 dark:text-gray-100"
+    className="h-6 w-6 text-gray-900 hover:text-primary-500 group-hover:text-primary-500 dark:text-gray-100 dark:hover:text-primary-400 dark:group-hover:text-primary-400"
   >
     <path
       fillRule="evenodd"
@@ -23,7 +23,7 @@ const Moon = () => (
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 20 20"
     fill="currentColor"
-    className="h-6 w-6 text-gray-900 dark:text-gray-100"
+    className="h-6 w-6 text-gray-900 hover:text-primary-500 group-hover:text-primary-500 dark:text-gray-100 dark:hover:text-primary-400 dark:group-hover:text-primary-400"
   >
     <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
   </svg>
@@ -37,7 +37,7 @@ const Monitor = () => (
     stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"
-    className="h-6 w-6 text-gray-900 dark:text-gray-100"
+    className="h-6 w-6 text-gray-900 group-hover:text-primary-500 dark:text-gray-100 dark:group-hover:text-primary-400"
   >
     <rect x="3" y="3" width="14" height="10" rx="2" ry="2"></rect>
     <line x1="7" y1="17" x2="13" y2="17"></line>
@@ -72,7 +72,7 @@ const ThemeSwitch = () => {
               <div className="p-1">
                 <RadioGroup.Option value="light">
                   <Menu.Item>
-                    <button className="group flex w-full items-center rounded-md px-2 py-2 text-sm">
+                    <button className="group flex w-full items-center rounded-md px-2 py-2 text-sm hover:text-primary-500 dark:hover:text-primary-400">
                       <div className="mr-2">
                         <Sun />
                       </div>
@@ -82,7 +82,7 @@ const ThemeSwitch = () => {
                 </RadioGroup.Option>
                 <RadioGroup.Option value="dark">
                   <Menu.Item>
-                    <button className="group flex w-full items-center rounded-md px-2 py-2 text-sm">
+                    <button className="group flex w-full items-center rounded-md px-2 py-2 text-sm hover:text-primary-500 dark:hover:text-primary-400">
                       <div className="mr-2">
                         <Moon />
                       </div>
@@ -92,7 +92,7 @@ const ThemeSwitch = () => {
                 </RadioGroup.Option>
                 <RadioGroup.Option value="system">
                   <Menu.Item>
-                    <button className="group flex w-full items-center rounded-md px-2 py-2 text-sm">
+                    <button className="group flex w-full items-center rounded-md px-2 py-2 text-sm hover:text-primary-500 dark:hover:text-primary-400">
                       <div className="mr-2">
                         <Monitor />
                       </div>


### PR DESCRIPTION
## `Enhancement`

Added hover highlight color classes to Header links/SVGS, ThemeSwitch menu

Other links in the blog also have highlight on hover, it seemed like the nav links should have highlighting as well.

### Visuals
<details>
<summary>Screenshots</summary>

#### No hover
<img width="397" alt="image" src="https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/5898009/99aeb742-cfe9-4243-be05-a2fab753cf4f">

#### Blog hovered
<img width="397" alt="image" src="https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/5898009/62fdbc9a-3a6a-475d-aa8e-f631c9681c33">

#### ThemeSwitch icon hovered
<img width="397" alt="image" src="https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/5898009/88902135-adc7-495e-8dfa-a1c7968bc6b0">

#### ThemeSwitch icon clicked, still hovered
<img width="397" alt="image" src="https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/5898009/3e21b8b6-cec5-4e4c-979c-66c7a388874c">

#### Menu Item hovered
<img width="397" alt="image" src="https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/5898009/1f9e4e09-cf88-46ff-a65e-72affdb56b64">

</details>
