### PR TITLE
Refactor MobileNav to use headlessui

### DIFF
--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -37,7 +37,7 @@ const MobileNav = () => {
       </button>
       <div
         className={`fixed left-0 top-0 z-10 h-full w-full transform bg-white opacity-95 duration-300 ease-in-out dark:bg-gray-950 dark:opacity-[0.98] ${
-          navShow ? 'translate-x-0' : 'translate-x-full'
+          navShow ? 'translate-x-0' : 'hidden translate-x-full'
         }`}
       >
         <div className="flex justify-end">

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -36,41 +36,73 @@ const MobileNav = () => {
           />
         </svg>
       </button>
-      <div
-        className={`fixed left-0 top-0 z-10 h-full w-full transform bg-white opacity-95 duration-300 ease-in-out dark:bg-gray-950 dark:opacity-[0.98] ${
-          navShow ? 'translate-x-0' : 'hidden translate-x-full'
-        }`}
-      >
-        <nav className="fixed mt-8 h-full">
-          {headerNavLinks.map((link) => (
-            <div key={link.title} className="px-12 py-4">
-              <Link
-                href={link.href}
-                className="text-2xl font-bold tracking-widest text-gray-900 dark:text-gray-100"
-                onClick={onToggleNav}
+
+      <Transition appear show={navShow} as={Fragment}>
+        <Dialog as="div" className="relative z-10" onClose={onToggleNav}>
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <div className="fixed inset-0 bg-black/25" />
+          </Transition.Child>
+
+          <div className="fixed inset-0 overflow-y-auto">
+            <div className="flex min-h-full items-center justify-center p-4 text-center">
+              <Transition.Child
+                as={Fragment}
+                enter="transition ease-in-out duration-300 transform"
+                enterFrom="translate-x-full opacity-0"
+                enterTo="translate-x-0 opacity-95"
+                leave="transition ease-in duration-200 transform"
+                leaveFrom="translate-x-0 opacity-95"
+                leaveTo="translate-x-full opacity-0"
               >
-                {link.title}
-              </Link>
+                <Dialog.Panel className="fixed left-0 top-0 z-10 h-full w-full bg-white opacity-95 duration-300 dark:bg-gray-950 dark:opacity-[0.98]">
+                  <nav className="fixed mt-8 h-full text-left">
+                    {headerNavLinks.map((link) => (
+                      <div key={link.title} className="px-12 py-4">
+                        <Link
+                          href={link.href}
+                          className="text-2xl font-bold tracking-widest text-gray-900 dark:text-gray-100"
+                          onClick={onToggleNav}
+                        >
+                          {link.title}
+                        </Link>
+                      </div>
+                    ))}
+                  </nav>
+
+                  <div className="flex justify-end">
+                    <button
+                      className="mr-8 mt-11 h-8 w-8"
+                      aria-label="Toggle Menu"
+                      onClick={onToggleNav}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        className="text-gray-900 dark:text-gray-100"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </Dialog.Panel>
+              </Transition.Child>
             </div>
-          ))}
-        </nav>
-        <div className="flex justify-end">
-          <button className="mr-8 mt-11 h-8 w-8" aria-label="Toggle Menu" onClick={onToggleNav}>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="text-gray-900 dark:text-gray-100"
-            >
-              <path
-                fillRule="evenodd"
-                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </button>
-        </div>
-      </div>
+          </div>
+        </Dialog>
+      </Transition>
     </>
   )
 }

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState } from 'react'
+import { Dialog, Transition } from '@headlessui/react'
+import { Fragment, useState } from 'react'
 import Link from './Link'
 import headerNavLinks from '@/data/headerNavLinks'
 

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -41,6 +41,19 @@ const MobileNav = () => {
           navShow ? 'translate-x-0' : 'hidden translate-x-full'
         }`}
       >
+        <nav className="fixed mt-8 h-full">
+          {headerNavLinks.map((link) => (
+            <div key={link.title} className="px-12 py-4">
+              <Link
+                href={link.href}
+                className="text-2xl font-bold tracking-widest text-gray-900 dark:text-gray-100"
+                onClick={onToggleNav}
+              >
+                {link.title}
+              </Link>
+            </div>
+          ))}
+        </nav>
         <div className="flex justify-end">
           <button className="mr-8 mt-11 h-8 w-8" aria-label="Toggle Menu" onClick={onToggleNav}>
             <svg
@@ -57,19 +70,6 @@ const MobileNav = () => {
             </svg>
           </button>
         </div>
-        <nav className="fixed mt-8 h-full">
-          {headerNavLinks.map((link) => (
-            <div key={link.title} className="px-12 py-4">
-              <Link
-                href={link.href}
-                className="text-2xl font-bold tracking-widest text-gray-900 dark:text-gray-100"
-                onClick={onToggleNav}
-              >
-                {link.title}
-              </Link>
-            </div>
-          ))}
-        </nav>
       </div>
     </>
   )


### PR DESCRIPTION
## `Enhancement`

Current mobile drawer doesn't take advantage of accessibility offered by `headlessui`

Used [`headlessui/Dialog`](https://headlessui.com/v1/react/dialog) as an example to refactor the `MobileNav` drawer

## Changes
 - Move close button to bottom of drawer HTML so it is not auto selected when entering `MobileNav`
 - Kept current `MobileNav` styling
 - Changed to `Dialog` as base component
   - Allows for tab press to stay within `Dialog`
   - Allows for esc press to close `Dialog`

## Visuals
<details>
<summary>Before Changes</summary>
<img width="617" alt="image" src="https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/5898009/21510b12-53d8-473b-8787-5d6340ea8d9c">
<img width="617" alt="image" src="https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/5898009/9aa9a129-4377-43cf-a556-f3b0cc5b30df">


</details>

<details>
<summary>After Changes</summary>

<img width="617" alt="image" src="https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/5898009/73768298-ca90-4471-85d7-824edb0c2f8c">
<img width="617" alt="image" src="https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/5898009/617b3410-98c7-4a5b-827e-16083310a2d1">


</details>