### PR TITLE
Fix button alignment in ThemeSwitch component

### DIFF
--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -54,7 +54,7 @@ const ThemeSwitch = () => {
   useEffect(() => setMounted(true), [])
 
   return (
-    <div className="flex items-center mr-5">
+    <div className="mr-5 flex items-center">
       <Menu as="div" className="relative inline-block text-left">
         <div className="flex items-center justify-center hover:text-primary-500 dark:hover:text-primary-400">
           <Menu.Button>

--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -54,9 +54,9 @@ const ThemeSwitch = () => {
   useEffect(() => setMounted(true), [])
 
   return (
-    <div className="mr-5">
+    <div className="flex items-center mr-5">
       <Menu as="div" className="relative inline-block text-left">
-        <div className="hover:text-primary-500 dark:hover:text-primary-400">
+        <div className="flex items-center justify-center hover:text-primary-500 dark:hover:text-primary-400">
           <Menu.Button>
             {mounted ? resolvedTheme === 'dark' ? <Moon /> : <Sun /> : <Blank />}
           </Menu.Button>


### PR DESCRIPTION
### Fix button alignment in ThemeSwitch component

This PR fixes the alignment issue of the button within the ThemeSwitch component. The button was not properly centered within its container, causing it to appear misaligned in the navigation bar. This fix ensures that the button is vertically centered.

#### Changes Made:
- Applied `flex` layout and alignment classes to the div containing `Menu.Button` in `ThemeSwitch.tsx`.

#### Before:
![image](https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/26163328/b7919a1c-a59f-4f02-bb4e-8abbc70a1d53)

#### After:
![image](https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/26163328/886597da-54fb-49a7-85f6-5fe93e125d38)
