### PR TITLE
Allow line breaks for <a> tags to keep body width on mobile

### DIFF
--- a/components/Link.tsx
+++ b/components/Link.tsx
@@ -8,14 +8,14 @@ const CustomLink = ({ href, ...rest }: LinkProps & AnchorHTMLAttributes<HTMLAnch
   const isAnchorLink = href && href.startsWith('#')
 
   if (isInternalLink) {
-    return <Link href={href} {...rest} />
+    return <Link className="break-words" href={href} {...rest} />
   }
 
   if (isAnchorLink) {
-    return <a href={href} {...rest} />
+    return <a className="break-words" href={href} {...rest} />
   }
 
-  return <a target="_blank" rel="noopener noreferrer" href={href} {...rest} />
+  return <a className="break-words" target="_blank" rel="noopener noreferrer" href={href} {...rest} />
 }
 
 export default CustomLink

--- a/components/Link.tsx
+++ b/components/Link.tsx
@@ -15,7 +15,9 @@ const CustomLink = ({ href, ...rest }: LinkProps & AnchorHTMLAttributes<HTMLAnch
     return <a className="break-words" href={href} {...rest} />
   }
 
-  return <a className="break-words" target="_blank" rel="noopener noreferrer" href={href} {...rest} />
+  return (
+    <a className="break-words" target="_blank" rel="noopener noreferrer" href={href} {...rest} />
+  )
 }
 
 export default CustomLink


### PR DESCRIPTION
[My blog's article](https://umihi.co/blog/20221226-login-aws-console-by-cli-credentials) has URL references at the end, and it create extra right margin on entire mobile layout. I confirmed that adding `className="break-words"` on `<a>` tags fixed that.

| **Before** | **After** |
| ------------- | ------------- |
| ![スクリーンショット 2024-07-07 11 32 36](https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/39179585/93358cc1-c3c0-496a-8baa-2307fe4a2966) | ![スクリーンショット 2024-07-07 11 32 31](https://github.com/timlrx/tailwind-nextjs-starter-blog/assets/39179585/a6398536-a626-4aff-8252-641e048c296b) |

Thank you for sharing this blog template.