### PR TITLE
`searchDocumentsPath` taking `BASE_PATH` into account

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -83,7 +83,7 @@ function createSearchIndex(allBlogs) {
     siteMetadata.search.kbarConfig.searchDocumentsPath
   ) {
     writeFileSync(
-      `public/${siteMetadata.search.kbarConfig.searchDocumentsPath}`,
+      `public/${path.basename(siteMetadata.search.kbarConfig.searchDocumentsPath)}`,
       JSON.stringify(allCoreContent(sortPosts(allBlogs)))
     )
     console.log('Local search index generated...')

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -81,7 +81,7 @@ const siteMetadata = {
   search: {
     provider: 'kbar', // kbar or algolia
     kbarConfig: {
-      searchDocumentsPath: 'search.json', // path to load documents to search
+      searchDocumentsPath: `${process.env.BASE_PATH || ''}/search.json`, // path to load documents to search
     },
     // provider: 'algolia',
     // algoliaConfig: {


### PR DESCRIPTION
READY TO MERGE

<kbd>cmd+k</kbd> is now working with or without a `BASE_PATH` build option.