### PR TITLE
Update contentlayer.config.ts

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -43,7 +43,7 @@ const icon = fromHtmlIsomorphic(
 const computedFields: ComputedFields = {
   readingTime: { type: 'json', resolve: (doc) => readingTime(doc.body.raw) },
   slug: {
-    type: 'string',
+    type: 'json',
     resolve: (doc) => doc._raw.flattenedPath.replace(/^.+?(\/)/, ''),
   },
   path: {


### PR DESCRIPTION
To use the TOC (Table of Contents) with the default string, you might encounter an error due to incompatibility with the TOC properties. When attempting to parse it, it may break because it is already a string. However, with these changes, it works fine:
![image](https://github.com/user-attachments/assets/93961bbe-c12e-4168-b438-db4615e38e8b)
