### PR TITLE
fix: resolve console warning when switching between light and dark modes

### DIFF
--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -34,9 +34,9 @@ const Monitor = () => (
     viewBox="0 0 20 20"
     fill="none"
     stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
     className="group:hover:text-gray-100 h-6 w-6"
   >
     <rect x="3" y="3" width="14" height="10" rx="2" ry="2"></rect>


### PR DESCRIPTION
This commit addresses the issue where an error was logged in the console when the user switched between light and dark modes. The warning was caused by the inappropriate use of SVG tags in JSX. The solution involved correcting the SVG tag usage to comply with JSX syntax requirements.

Closes #974 