### PR TITLE
Add beehiiv as newsletter platform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,7 @@ EMAILOCTOPUS_API_KEY=
 # List ID can be found in the URL as a UUID after clicking a list on https://emailoctopus.com/lists
 # or the settings page of your list https://emailoctopus.com/lists/{UUID}/settings
 EMAILOCTOPUS_LIST_ID=
+
+# Create Beehive API key at https://developers.beehiiv.com/docs/v2/bktd9a7mxo67n-create-an-api-key
+BEEHIVE_API_KEY=
+BEEHIVE_PUBLICATION_ID=

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ I wanted it to be nearly as feature-rich as popular blogging templates like [bea
 - Integration with [pliny](https://github.com/timlrx/pliny) that provides:
   - Multiple analytics options including [Umami](https://umami.is/), [Plausible](https://plausible.io/), [Simple Analytics](https://simpleanalytics.com/), Posthog and Google Analytics
   - Comments via [Giscus](https://github.com/laymonage/giscus), [Utterances](https://github.com/utterance/utterances) or Disqus
-  - Newsletter API and component with support for Mailchimp, Buttondown, Convertkit, Klaviyo, Revue, and Emailoctopus
+  - Newsletter API and component with support for Mailchimp, Buttondown, Convertkit, Klaviyo, Revue, Emailoctopus and Beehiiv
   - Command palette search with [Kbar](https://github.com/timc1/kbar) or Algolia
 - Server-side syntax highlighting with line numbers and line highlighting via [rehype-prism-plus](https://github.com/timlrx/rehype-prism-plus)
 - Math display supported via [KaTeX](https://katex.org/)

--- a/data/blog/introducing-tailwind-nextjs-starter-blog.mdx
+++ b/data/blog/introducing-tailwind-nextjs-starter-blog.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Introducing Tailwind Nextjs Starter Blog'
 date: '2021-01-12'
-lastmod: '2024-06-02'
+lastmod: '2024-08-16'
 tags: ['next-js', 'tailwind', 'guide']
 draft: false
 summary: 'Looking for a performant, out of the box template, with all the best in web technology to support your blogging needs? Checkout the Tailwind Nextjs Starter Blog template.'
@@ -63,7 +63,7 @@ I wanted it to be nearly as feature-rich as popular blogging templates like [bea
 - Blog templates
 - TOC component
 - Support for nested routing of blog posts
-- Newsletter component with support for mailchimp, buttondown and convertkit
+- Newsletter component with support for Mailchimp, Buttondown, Convertkit, Klaviyo, Revue, Emailoctopus and Beehiiv
 - Supports [giscus](https://github.com/laymonage/giscus), [utterances](https://github.com/utterance/utterances) or disqus
 - Projects page
 - Preconfigured security headers

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -46,7 +46,7 @@ const siteMetadata = {
     // },
   },
   newsletter: {
-    // supports mailchimp, buttondown, convertkit, klaviyo, revue, emailoctopus
+    // supports mailchimp, buttondown, convertkit, klaviyo, revue, emailoctopus, beehive
     // Please add your .env file and modify it according to your selection
     provider: 'buttondown',
   },


### PR DESCRIPTION
Added beehiv in `pliny` in [this PR](https://github.com/timlrx/pliny/pull/177). After the `pliny` pr got merged beehiiv should be available in the package and this PR can be merged. 

This PR introduces information that the beehiiv newsletter api is availble in the `pliny` package and introduces the correspoinding environmental variables in the `.env.example`.