### PR TITLE
ReactElement is better type than ReactNode as it has the generic props

### DIFF
--- a/layouts/PostBanner.tsx
+++ b/layouts/PostBanner.tsx
@@ -12,7 +12,7 @@ import ScrollTopAndComment from '@/components/ScrollTopAndComment'
 
 interface LayoutProps {
   content: CoreContent<Blog>
-  children: ReactNode
+  children: ReactElement
   next?: { path: string; title: string }
   prev?: { path: string; title: string }
 }


### PR DESCRIPTION
more here - https://stackoverflow.com/questions/58123398/when-to-use-jsx-element-vs-reactnode-vs-reactelement