### PR TITLE
Allow Microsoft Clarity script in Content Security Policy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 // You might need to insert additional domains in script-src if you are using external services
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is;
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is https://www.clarity.ms;
   style-src 'self' 'unsafe-inline';
   img-src * blob: data:;
   media-src *.s3.amazonaws.com;


### PR DESCRIPTION
- Add https://www.clarity.ms/ to script-src directive in CSP
- Resolve script loading error related to Clarity
![image](https://github.com/user-attachments/assets/3e95298b-ea4d-4722-addf-3bf30b5a7a77)
