### PR TITLE
[update] update the new domain for blog site

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Internationalization support - [Template with i18n](https://tailwind-nextjs-star
 - [homing.so](https://homing.so) - Homing's personal blog about the stuff he's learning ([source code](https://github.com/hominsu/blog))
 - [zS1m's Blog](https://contrails.space) - zS1m's personal blog for recording and sharing daily learning technical content ([source code](https://github.com/zS1m/nextjs-contrails))
 - [dariuszwozniak.net](https://dariuszwozniak.net/) - Software development blog
-- [Terminals.run](https://terminals.run) - Blog site for some thoughts and records for life and technology.
+- [dreams.plus](https://dreams.plus) - Blog site for some thoughts and records for life and technology.
 - [francisaguilar.co blog](https://francisaguilar.co) - Francis Aguilar's personal blog that talks about tech, fitness, and personal development.
 - [Min71 Dev Blog](https://min71.dev) - Personal blog about Blockchain, Development and etc. ([source code](https://github.com/mingi3442/blog))
 - [Bryce Yu's Blog](https://earayu.github.io/) - Bryce Yu's personal Blog about distributed system, database, and web development. ([source code](https://github.com/earayu/earayu.github.io))


### PR DESCRIPTION
The old domain [terminals.run](terminals.run) has been deprecated. To avoid being a dead link, I have change them for new one [dreams.plus](dreams.plus)