### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18-alpine AS production
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+RUN corepack enable
+RUN corepack prepare yarn@3.6.1 --activate
+WORKDIR /app
+COPY package.json ./
+COPY yarn.lock ./
+COPY . .
+RUN yarn install
+RUN EXPORT=1 UNOPTIMIZED=1 BASE_PATH=/blog yarn build # remove BASE_PATH IF FAILING
+
+CMD ["yarn", "serve"]


### PR DESCRIPTION
## Add Docker Support for Tailwind Next.js Starter Blog

This PR adds Docker support for the [Tailwind Next.js Starter Blog](https://github.com/timlrx/tailwind-nextjs-starter-blog), allowing users to easily run and deploy the blog in a containerized environment.

### Why This Change
After reviewing [Issue #1004](https://github.com/timlrx/tailwind-nextjs-starter-blog/issues/1004), I realized the current documentation lacked guidance on setting up Docker for this project. The solution provided by @timlrx didn’t fully address the issue, and I spent around 4 hours troubleshooting to understand and resolve it.

### Changes Made
- Added `Dockerfile` for building the Next.js blog

### Benefits
- Simplifies deployment and local setup for users familiar with Docker
- Ensures consistency across different environments

### Related Issue
Closes #1004

### Additional Notes
Let me know if there are any adjustments or additional documentation needed. I hope this contribution makes Docker support accessible and reduces troubleshooting time for others!

