### PR TITLE
Add Schedles blog example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Internationalization support - [Template with i18n](https://tailwind-nextjs-star
 - [armujahid.me](https://armujahid.me/) - Abdul Rauf's personal blog about tech and random stuff.
 - [leohuynh.dev](leohuynh.dev) - 🇻🇳 Leo's dev blog – stories, insights, and ideas. Add `/snippets`, `/books` pages, add `ProfileCard`, `CareerTimeline` components and many more.
 - [OpenSats Blog](https://opensats.org/blog) - A 501(c)(3) public charity which aims to sustainably fund free and open-source projects. ([source code](https://github.com/OpenSats/website))
+- [Schedles Blog](https://schedles.com/blog) - Social media scheduling tips, strategies, and product updates for content creators. ([Project Link](https://schedles.com))
 
 Using the template? Feel free to create a PR and add your blog to this list.
 


### PR DESCRIPTION
## Add New Example Blog Link

### Summary
In order to not to push everything in one PR I have separated this one change with #1046 
This PR adds my blog link as an example on the Tailwind Next.js Starter Blog.

### Motivation
Including my blog in the examples section provides new users with a live, functional reference of a blog created using this starter template. It can help showcase the capabilities of the template in real-world usage.

### Changes
- **Example blog link**:
  - Added my blog link to the examples section for easier reference by other users.

### Additional Notes
Let me know if any adjustments are needed. I hope this addition adds value to the project by demonstrating a live blog example.
