### PR TITLE
Added support for youtube social icon below the profile image in the about page

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -139,6 +139,7 @@ export const Authors = defineDocumentType(() => ({
     twitter: { type: 'string' },
     linkedin: { type: 'string' },
     github: { type: 'string' },
+    youtube: { type: 'string' },
     layout: { type: 'string' },
   },
   computedFields,

--- a/data/authors/default.mdx
+++ b/data/authors/default.mdx
@@ -7,6 +7,7 @@ email: address@yoursite.com
 twitter: https://twitter.com/Twitter
 linkedin: https://www.linkedin.com
 github: https://github.com
+youtube: https://youtube.com
 ---
 
 Tails Azimuth is a professor of atmospheric sciences at the Stanford AI Lab. His research interests includes complexity modelling of tailwinds, headwinds and crosswinds.

--- a/layouts/AuthorLayout.tsx
+++ b/layouts/AuthorLayout.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 export default function AuthorLayout({ children, content }: Props) {
-  const { name, avatar, occupation, company, email, twitter, linkedin, github } = content
+  const { name, avatar, occupation, company, email, twitter, linkedin, github, youtube } = content
 
   return (
     <>
@@ -36,6 +36,7 @@ export default function AuthorLayout({ children, content }: Props) {
             <div className="flex space-x-3 pt-6">
               <SocialIcon kind="mail" href={`mailto:${email}`} />
               <SocialIcon kind="github" href={github} />
+              <SocialIcon kind="youtube" href={youtube} />
               <SocialIcon kind="linkedin" href={linkedin} />
               <SocialIcon kind="x" href={twitter} />
             </div>


### PR DESCRIPTION
Added support for youtube social icon below the profile image in the about page.

So now in the default author mdx file, you can put your youtube link, then run `yarn build`, and `yarn dev`, and it will show youtube icon in the about page below the profile image along with other social media icons.