### PR TITLE
Add /authors

### DIFF
--- a/app/authors/[slug]/page.tsx
+++ b/app/authors/[slug]/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from 'next/navigation'
+import { Authors, allAuthors } from 'contentlayer/generated'
+import { MDXLayoutRenderer } from 'pliny/mdx-components'
+import AuthorLayout from '@/layouts/AuthorLayout'
+import { coreContent } from 'pliny/utils/contentlayer'
+
+
+export async function generateStaticParams() {
+  return allAuthors.map((author) => ({
+    slug: author.slug,
+  }))
+}
+
+export default async function AuthorPage({ params }: { params: { slug: string } }) {
+  const { slug } = await params
+
+  const author = allAuthors.find((p) => p.slug === slug) as Authors | undefined
+
+  if (!author) {
+    notFound()
+  }
+
+  const mainContent = coreContent(author)
+
+  return (
+      <AuthorLayout content={mainContent}>
+        <MDXLayoutRenderer code={author.body.code} />
+      </AuthorLayout>
+  )
+}

--- a/app/authors/page.tsx
+++ b/app/authors/page.tsx
@@ -1,0 +1,29 @@
+import { Authors, allAuthors } from 'contentlayer/generated'
+import { MDXLayoutRenderer } from 'pliny/mdx-components'
+import AuthorLayout from '@/layouts/AuthorLayout'
+import Link from 'next/link'
+import { coreContent } from 'pliny/utils/contentlayer'
+import { genPageMetadata } from 'app/seo'
+
+export const metadata = genPageMetadata({ title: 'About' })
+
+export default function Page() {
+  return (
+    <>
+      <h1>Authors</h1>
+      <div>
+        {allAuthors.map((author) => {
+          const mainContent = coreContent(author)
+
+          return (
+            <div key={author.slug} className="author-card">
+              <Link href={`/authors/${author.slug}`}>
+                <h2>{author.name}</h2>
+              </Link>
+            </div>
+          )
+        })}
+      </div>
+    </>
+  )
+}

--- a/components/Author.tsx
+++ b/components/Author.tsx
@@ -1,0 +1,27 @@
+import { MDXLayoutRenderer } from 'pliny/mdx-components'
+import { useEffect, useState } from 'react'
+
+interface AuthorProps {
+  author: {
+    slug: string
+    name: string
+    bio: string
+    body: { code: string }
+  }
+}
+
+const Author = ({ author }: AuthorProps) => {
+  const [authorData, setAuthorData] = useState(author)
+
+  useEffect(() => {
+    setAuthorData(author)
+  }, [author])
+
+  return (
+    <div>
+      <h1>{authorData.name}</h1>
+      <p>{authorData.bio}</p>
+      <MDXLayoutRenderer code={authorData.body.code} />
+    </div>
+  )
+}

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -63,17 +63,26 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                   {authorDetails.map((author) => (
                     <li className="flex items-center space-x-2" key={author.name}>
                       {author.avatar && (
-                        <Image
-                          src={author.avatar}
-                          width={38}
-                          height={38}
-                          alt="avatar"
-                          className="h-10 w-10 rounded-full"
-                        />
+                        <Link href={`/authors/${author.slug}`}>
+                          <Image
+                            src={author.avatar}
+                            width={38}
+                            height={38}
+                            alt={`${author.name}'s avatar`}
+                            className="h-10 w-10 rounded-full"
+                          />
+                        </Link>
                       )}
                       <dl className="whitespace-nowrap text-sm font-medium leading-5">
                         <dt className="sr-only">Name</dt>
-                        <dd className="text-gray-900 dark:text-gray-100">{author.name}</dd>
+                        <dd>
+                          <Link
+                            href={`/authors/${author.slug}`}
+                            className="text-gray-900 dark:text-gray-100"
+                          >
+                            {author.name}
+                          </Link>
+                        </dd>
                         <dt className="sr-only">Twitter</dt>
                         <dd>
                           {author.twitter && (
@@ -100,7 +109,6 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                   Discuss on Twitter
                 </Link>
                 {` • `}
-                <Link href={editUrl(filePath)}>View on GitHub</Link>
               </div>
               {siteMetadata.comments && (
                 <div


### PR DESCRIPTION
I was missing https://yawdev.org/blog/authors page on my blog, so I decided to add this functionality:
The page itself is very simple, since I'am not frontend dev at all.
![image](https://github.com/user-attachments/assets/2c3161f5-dace-4ca2-9fee-b7c9cb208072)
Also I have added "Author" pages for each author in the directory:
https://yawdev.org/blog/authors/evgenyshut
![image](https://github.com/user-attachments/assets/092f25c3-5a07-46b5-be53-0c8c49173361)
On the any blog post with authors listed - you can go to the author profile by clicking on Author Image or It's name:
https://yawdev.org/blog/blog/1-introducing-yawdev
![image](https://github.com/user-attachments/assets/97f5251b-98e9-401b-9548-4e0b424f10ea)

