### PR TITLE
Ts.add hover styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Internationalization support - [Template with i18n](https://tailwind-nextjs-star
 - [YawDev Blog](https://yawdev.org/blog) - IT-Agency / Software Development. Blog about tech and business ([Project Link](https://yawdev.org))
 - [Engineering Notes](https://www.jonvet.com) - Jonas Vetterle Personal Website & Blog. I'm writing articles about software engineering that interest me, including AI and Quantum Computing
 - [Screenager.dev](https://screenager.vercel.app) - Personal Website as Portfolio & Blog. Documenting my learning journey and some guides.
+- [kezhenxu94's blog](https://kezhenxu94.me) - Blogging about dev, tips & tricks, tutorials and more.
 
 Using the template? Feel free to create a PR and add your blog to this list.
 

--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -3,6 +3,7 @@ import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import { formatDate } from 'pliny/utils/formatDate'
 import NewsletterForm from 'pliny/ui/NewsletterForm'
+import { ListLayoutBase } from '@/layouts/ListLayoutWithTags'
 
 const MAX_DISPLAY = 5
 
@@ -20,54 +21,7 @@ export default function Home({ posts }) {
         </div>
         <ul className="divide-y divide-gray-200 dark:divide-gray-700">
           {!posts.length && 'No posts found.'}
-          {posts.slice(0, MAX_DISPLAY).map((post) => {
-            const { slug, date, title, summary, tags } = post
-            return (
-              <li key={slug} className="py-12">
-                <article>
-                  <div className="space-y-2 xl:grid xl:grid-cols-4 xl:items-baseline xl:space-y-0">
-                    <dl>
-                      <dt className="sr-only">Published on</dt>
-                      <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
-                        <time dateTime={date}>{formatDate(date, siteMetadata.locale)}</time>
-                      </dd>
-                    </dl>
-                    <div className="space-y-5 xl:col-span-3">
-                      <div className="space-y-6">
-                        <div>
-                          <h2 className="text-2xl font-bold leading-8 tracking-tight">
-                            <Link
-                              href={`/blog/${slug}`}
-                              className="text-gray-900 dark:text-gray-100"
-                            >
-                              {title}
-                            </Link>
-                          </h2>
-                          <div className="flex flex-wrap">
-                            {tags.map((tag) => (
-                              <Tag key={tag} text={tag} />
-                            ))}
-                          </div>
-                        </div>
-                        <div className="prose max-w-none text-gray-500 dark:text-gray-400">
-                          {summary}
-                        </div>
-                      </div>
-                      <div className="text-base font-medium leading-6">
-                        <Link
-                          href={`/blog/${slug}`}
-                          className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
-                          aria-label={`Read more: "${title}"`}
-                        >
-                          Read more &rarr;
-                        </Link>
-                      </div>
-                    </div>
-                  </div>
-                </article>
-              </li>
-            )
-          })}
+          <ListLayoutBase dateToSide={true} posts={posts} readMore={true} />
         </ul>
       </div>
       {posts.length > MAX_DISPLAY && (

--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -19,7 +19,7 @@ export default function Home({ posts }) {
         </div>
         <ul className="divide-y divide-gray-200 dark:divide-gray-700">
           {!posts.length && 'No posts found.'}
-          <ListLayoutBase dateToSide={true} posts={posts} readMore={true} />
+          <ListLayoutBase dateToSide={true} posts={posts} readMore={true} divideY={true} />
         </ul>
       </div>
       {posts.length > MAX_DISPLAY && (

--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -3,7 +3,7 @@ import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import { formatDate } from 'pliny/utils/formatDate'
 import NewsletterForm from 'pliny/ui/NewsletterForm'
-import { ListLayoutBase } from '@/layouts/ListLayoutWithTags'
+import ListLayoutBase from '@/components/ListLayoutBase'
 
 const MAX_DISPLAY = 5
 

--- a/app/Main.tsx
+++ b/app/Main.tsx
@@ -1,7 +1,5 @@
 import Link from '@/components/Link'
-import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
-import { formatDate } from 'pliny/utils/formatDate'
 import NewsletterForm from 'pliny/ui/NewsletterForm'
 import ListLayoutBase from '@/components/ListLayoutBase'
 

--- a/components/ListLayoutBase.tsx
+++ b/components/ListLayoutBase.tsx
@@ -25,7 +25,7 @@ export function ListLayoutBase({
         {posts.map((post) => {
           const { path, date, title, summary, tags } = post
           return (
-            <li key={path} className="py-3">
+            <li key={path} className="py-10">
               <article>
                 <div
                   className={clsx({

--- a/components/ListLayoutBase.tsx
+++ b/components/ListLayoutBase.tsx
@@ -4,14 +4,18 @@ import { formatDate } from 'pliny/utils/formatDate'
 import Link from '@/components/Link'
 import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
+import type { Blog } from 'contentlayer/generated'
 import clsx from 'clsx'
-import Pagination from '@/components/Pagination'
+import Pagination, { PaginationProps } from '@/components/Pagination'
 import { ListLayoutProps } from '@/layouts/ListLayoutWithTags'
+import { CoreContent } from 'pliny/utils/contentlayer'
 
-interface ListLayoutBaseProps extends ListLayoutProps {
+interface ListLayoutBaseProps {
   readMore?: boolean
   dateToSide?: boolean
   divideY?: boolean
+  pagination?: PaginationProps
+  posts: Blog[]
 }
 
 export function ListLayoutBase({

--- a/components/ListLayoutBase.tsx
+++ b/components/ListLayoutBase.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { formatDate } from 'pliny/utils/formatDate'
+import Link from '@/components/Link'
+import Tag from '@/components/Tag'
+import siteMetadata from '@/data/siteMetadata'
+import clsx from 'clsx'
+import Pagination from '@/components/Pagination'
+import { ListLayoutProps } from '@/layouts/ListLayoutWithTags'
+
+interface ListLayoutBaseProps extends ListLayoutProps {
+  readMore?: boolean
+  dateToSide?: boolean
+}
+
+export function ListLayoutBase({
+  posts,
+  pagination,
+  readMore = false,
+  dateToSide = false,
+}: ListLayoutBaseProps) {
+  return (
+    <div className="w-full">
+      <ul>
+        {posts.map((post) => {
+          const { path, date, title, summary, tags } = post
+          return (
+            <li key={path} className="py-3">
+              <article>
+                <div
+                  className={clsx({
+                    'space-y-2 xl:grid xl:grid-cols-4 xl:items-baseline xl:space-y-0':
+                      dateToSide === true,
+                    'pointer mb-1 flex flex-col space-y-2 transition-colors xl:space-y-0':
+                      dateToSide === false,
+                  })}
+                >
+                  {dateToSide && (
+                    <dl className="hidden xl:block">
+                      <dt className="sr-only">Published on</dt>
+                      <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
+                        <time dateTime={date} suppressHydrationWarning>
+                          {formatDate(date, siteMetadata.locale)}
+                        </time>
+                      </dd>
+                    </dl>
+                  )}
+                  <div className={clsx({ 'space-y-5 xl:col-span-3': dateToSide === true })}>
+                    <Link className="group" href={`/${path}`}>
+                      <div className="mb-2 rounded-lg border border-transparent p-2 group-hover:border-primary-400 group-hover:bg-primary-100 dark:hover:bg-primary-900">
+                        <dl className={clsx({ 'block xl:hidden': dateToSide, block: !dateToSide })}>
+                          <dt className="sr-only">Published on</dt>
+                          <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
+                            <time dateTime={date} suppressHydrationWarning>
+                              {formatDate(date, siteMetadata.locale)}
+                            </time>
+                          </dd>
+                        </dl>
+
+                        <div>
+                          <div>
+                            <h2 className="text-2xl font-bold leading-8 tracking-tight">
+                              <p className="text-gray-900 dark:text-gray-100">{title}</p>
+                            </h2>
+                          </div>
+                          <div className="prose max-w-none text-gray-500 dark:text-gray-400">
+                            {summary}
+                          </div>
+                          {readMore && (
+                            <div className="font-medium leading-6 text-primary-500 group-hover:text-primary-300">
+                              Read more &rarr;
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </Link>
+                    <div className="flex flex-row flex-wrap gap-1">
+                      {tags?.map((tag) => <Tag key={tag} text={tag} />)}
+                    </div>
+                  </div>
+                </div>
+              </article>
+            </li>
+          )
+        })}
+      </ul>
+      {pagination && pagination.totalPages > 1 && (
+        <Pagination currentPage={pagination.currentPage} totalPages={pagination.totalPages} />
+      )}
+    </div>
+  )
+}
+
+export default ListLayoutBase

--- a/components/ListLayoutBase.tsx
+++ b/components/ListLayoutBase.tsx
@@ -11,6 +11,7 @@ import { ListLayoutProps } from '@/layouts/ListLayoutWithTags'
 interface ListLayoutBaseProps extends ListLayoutProps {
   readMore?: boolean
   dateToSide?: boolean
+  divideY?: boolean
 }
 
 export function ListLayoutBase({
@@ -18,10 +19,11 @@ export function ListLayoutBase({
   pagination,
   readMore = false,
   dateToSide = false,
+  divideY = false,
 }: ListLayoutBaseProps) {
   return (
     <div className="w-full">
-      <ul>
+      <ul className={clsx({ 'divide-y divide-gray-200 dark:divide-gray-700': divideY })}>
         {posts.map((post) => {
           const { path, date, title, summary, tags } = post
           return (

--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import Link from '@/components/Link'
+
+export interface PaginationProps {
+  totalPages: number
+  currentPage: number
+}
+
+function Pagination({ totalPages, currentPage }: PaginationProps) {
+  const pathname = usePathname()
+  const basePath = pathname.split('/')[1]
+  const prevPage = currentPage - 1 > 0
+  const nextPage = currentPage + 1 <= totalPages
+
+  return (
+    <div className="space-y-2 pb-8 pt-6 md:space-y-5">
+      <nav className="flex justify-between">
+        {!prevPage && (
+          <button className="cursor-auto disabled:opacity-50" disabled={!prevPage}>
+            Previous
+          </button>
+        )}
+        {prevPage && (
+          <Link
+            href={currentPage - 1 === 1 ? `/${basePath}/` : `/${basePath}/page/${currentPage - 1}`}
+            rel="prev"
+          >
+            Previous
+          </Link>
+        )}
+        <span>
+          {currentPage} of {totalPages}
+        </span>
+        {!nextPage && (
+          <button className="cursor-auto disabled:opacity-50" disabled={!nextPage}>
+            Next
+          </button>
+        )}
+        {nextPage && (
+          <Link href={`/${basePath}/page/${currentPage + 1}`} rel="next">
+            Next
+          </Link>
+        )}
+      </nav>
+    </div>
+  )
+}
+
+export default Pagination

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -8,7 +8,7 @@ const Tag = ({ text }: Props) => {
   return (
     <Link
       href={`/tags/${slug(text)}`}
-      className="mr-3 rounded-lg border border-primary-400 p-1 px-2 text-sm font-medium uppercase text-primary-500 transition-colors hover:bg-primary-100 hover:text-primary-600 dark:hover:bg-primary-800  dark:hover:text-primary-400 "
+      className="my-1 mr-3 rounded-lg border border-primary-400 p-1 px-2 text-sm font-medium uppercase text-primary-500 transition-colors hover:bg-primary-100 hover:text-primary-600 dark:hover:bg-primary-800  dark:hover:text-primary-400 "
     >
       {text.split(' ').join('-')}
     </Link>

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -8,7 +8,7 @@ const Tag = ({ text }: Props) => {
   return (
     <Link
       href={`/tags/${slug(text)}`}
-      className="mr-3 text-sm font-medium uppercase text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+      className="mr-3 rounded-lg border border-primary-400 p-1 px-2 text-sm font-medium uppercase text-primary-500 transition-colors hover:bg-primary-100 hover:text-primary-600 dark:hover:bg-primary-800  dark:hover:text-primary-400 "
     >
       {text.split(' ').join('-')}
     </Link>

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -187,14 +187,8 @@ export function ListLayoutBase({
                             {summary}
                           </div>
                           {readMore && (
-                            <div className="text-base font-medium leading-6">
-                              <Link
-                                href={`/blog/${slug}`}
-                                className="text-primary-500 group-hover:text-primary-600 dark:group-hover:text-primary-400"
-                                aria-label={`Read more: "${title}"`}
-                              >
-                                Read more &rarr;
-                              </Link>
+                            <div className="font-medium leading-6 text-primary-500 group-hover:text-primary-300">
+                              Read more &rarr;
                             </div>
                           )}
                         </div>

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -84,7 +84,7 @@ export default function ListLayoutWithTags({
         </div>
         <div className="flex sm:space-x-24">
           <div className="hidden h-full max-h-screen min-w-[280px] max-w-[280px] flex-wrap overflow-auto rounded bg-gray-50 pt-5 shadow-md dark:bg-gray-900/70 dark:shadow-gray-800/40 sm:flex">
-            <div className="px-6 py-4">
+            <div className="w-full py-4 pl-6">
               {pathname.startsWith('/blog') ? (
                 <h3 className="font-bold uppercase text-primary-500">All Posts</h3>
               ) : (
@@ -106,7 +106,7 @@ export default function ListLayoutWithTags({
                       ) : (
                         <Link
                           href={`/tags/${slug(t)}`}
-                          className="px-3 py-2 text-sm font-medium uppercase text-gray-500 hover:text-primary-500 dark:text-gray-300 dark:hover:text-primary-500"
+                          className="py-2 pl-3 pr-1 text-sm font-medium uppercase text-gray-500 hover:text-primary-500 dark:text-gray-300 dark:hover:text-primary-500"
                           aria-label={`View posts tagged ${t}`}
                         >
                           {`${t} (${tagCounts[t]})`}

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -10,56 +10,14 @@ import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import tagData from 'app/tag-data.json'
 import clsx from 'clsx'
+import type { PaginationProps } from '@/components/Pagination'
+import Pagination from '@/components/Pagination'
 
-interface PaginationProps {
-  totalPages: number
-  currentPage: number
-}
 interface ListLayoutProps {
   posts: CoreContent<Blog>[]
   title?: string
   initialDisplayPosts?: CoreContent<Blog>[]
   pagination?: PaginationProps
-}
-
-function Pagination({ totalPages, currentPage }: PaginationProps) {
-  const pathname = usePathname()
-  const basePath = pathname.split('/')[1]
-  const prevPage = currentPage - 1 > 0
-  const nextPage = currentPage + 1 <= totalPages
-
-  return (
-    <div className="space-y-2 pb-8 pt-6 md:space-y-5">
-      <nav className="flex justify-between">
-        {!prevPage && (
-          <button className="cursor-auto disabled:opacity-50" disabled={!prevPage}>
-            Previous
-          </button>
-        )}
-        {prevPage && (
-          <Link
-            href={currentPage - 1 === 1 ? `/${basePath}/` : `/${basePath}/page/${currentPage - 1}`}
-            rel="prev"
-          >
-            Previous
-          </Link>
-        )}
-        <span>
-          {currentPage} of {totalPages}
-        </span>
-        {!nextPage && (
-          <button className="cursor-auto disabled:opacity-50" disabled={!nextPage}>
-            Next
-          </button>
-        )}
-        {nextPage && (
-          <Link href={`/${basePath}/page/${currentPage + 1}`} rel="next">
-            Next
-          </Link>
-        )}
-      </nav>
-    </div>
-  )
 }
 
 export default function ListLayoutWithTags({

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -11,7 +11,7 @@ import ListLayoutBase from '@/components/ListLayoutBase'
 
 export interface ListLayoutProps {
   posts: CoreContent<Blog>[]
-  title?: string
+  title: string
   initialDisplayPosts?: CoreContent<Blog>[]
   pagination?: PaginationProps
 }
@@ -35,7 +35,7 @@ export default function ListLayoutWithTags({
         {title && (
           <div className="pb-6 pt-6">
             <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:hidden sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
-              {title}
+              {title} Zzzzzzz bonk
             </h1>
           </div>
         )}

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -12,6 +12,7 @@ import tagData from 'app/tag-data.json'
 import clsx from 'clsx'
 import type { PaginationProps } from '@/components/Pagination'
 import Pagination from '@/components/Pagination'
+import ListLayoutBase from '@/components/ListLayoutBase'
 
 export interface ListLayoutProps {
   posts: CoreContent<Blog>[]
@@ -83,88 +84,5 @@ export default function ListLayoutWithTags({
         </div>
       </div>
     </>
-  )
-}
-
-interface ListLayoutBaseProps extends ListLayoutProps {
-  readMore?: boolean
-  dateToSide?: boolean
-}
-
-export function ListLayoutBase({
-  posts,
-  pagination,
-  readMore = false,
-  dateToSide = false,
-}: ListLayoutBaseProps) {
-  return (
-    <div className="w-full">
-      <ul>
-        {posts.map((post) => {
-          const { path, date, title, summary, tags } = post
-          return (
-            <li key={path} className="py-3">
-              <article>
-                <div
-                  className={clsx({
-                    'space-y-2 xl:grid xl:grid-cols-4 xl:items-baseline xl:space-y-0':
-                      dateToSide === true,
-                    'pointer mb-1 flex flex-col space-y-2 transition-colors xl:space-y-0':
-                      dateToSide === false,
-                  })}
-                >
-                  {dateToSide && (
-                    <dl className="hidden xl:block">
-                      <dt className="sr-only">Published on</dt>
-                      <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
-                        <time dateTime={date} suppressHydrationWarning>
-                          {formatDate(date, siteMetadata.locale)}
-                        </time>
-                      </dd>
-                    </dl>
-                  )}
-                  <div className={clsx({ 'space-y-5 xl:col-span-3': dateToSide === true })}>
-                    <Link className="group" href={`/${path}`}>
-                      <div className="mb-2 rounded-lg border border-transparent p-2 group-hover:border-primary-400 group-hover:bg-primary-100 dark:hover:bg-primary-900">
-                        <dl className={clsx({ 'block xl:hidden': dateToSide, block: !dateToSide })}>
-                          <dt className="sr-only">Published on</dt>
-                          <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
-                            <time dateTime={date} suppressHydrationWarning>
-                              {formatDate(date, siteMetadata.locale)}
-                            </time>
-                          </dd>
-                        </dl>
-
-                        <div>
-                          <div>
-                            <h2 className="text-2xl font-bold leading-8 tracking-tight">
-                              <p className="text-gray-900 dark:text-gray-100">{title}</p>
-                            </h2>
-                          </div>
-                          <div className="prose max-w-none text-gray-500 dark:text-gray-400">
-                            {summary}
-                          </div>
-                          {readMore && (
-                            <div className="font-medium leading-6 text-primary-500 group-hover:text-primary-300">
-                              Read more &rarr;
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    </Link>
-                    <div className="flex flex-row flex-wrap gap-1">
-                      {tags?.map((tag) => <Tag key={tag} text={tag} />)}
-                    </div>
-                  </div>
-                </div>
-              </article>
-            </li>
-          )
-        })}
-      </ul>
-      {pagination && pagination.totalPages > 1 && (
-        <Pagination currentPage={pagination.currentPage} totalPages={pagination.totalPages} />
-      )}
-    </div>
   )
 }

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -13,7 +13,7 @@ import clsx from 'clsx'
 import type { PaginationProps } from '@/components/Pagination'
 import Pagination from '@/components/Pagination'
 
-interface ListLayoutProps {
+export interface ListLayoutProps {
   posts: CoreContent<Blog>[]
   title?: string
   initialDisplayPosts?: CoreContent<Blog>[]

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -2,16 +2,11 @@
 
 import { usePathname } from 'next/navigation'
 import { slug } from 'github-slugger'
-import { formatDate } from 'pliny/utils/formatDate'
 import { CoreContent } from 'pliny/utils/contentlayer'
 import type { Blog } from 'contentlayer/generated'
 import Link from '@/components/Link'
-import Tag from '@/components/Tag'
-import siteMetadata from '@/data/siteMetadata'
 import tagData from 'app/tag-data.json'
-import clsx from 'clsx'
 import type { PaginationProps } from '@/components/Pagination'
-import Pagination from '@/components/Pagination'
 import ListLayoutBase from '@/components/ListLayoutBase'
 
 export interface ListLayoutProps {

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -9,6 +9,7 @@ import Link from '@/components/Link'
 import Tag from '@/components/Tag'
 import siteMetadata from '@/data/siteMetadata'
 import tagData from 'app/tag-data.json'
+import clsx from 'clsx'
 
 interface PaginationProps {
   totalPages: number
@@ -16,7 +17,7 @@ interface PaginationProps {
 }
 interface ListLayoutProps {
   posts: CoreContent<Blog>[]
-  title: string
+  title?: string
   initialDisplayPosts?: CoreContent<Blog>[]
   pagination?: PaginationProps
 }
@@ -77,12 +78,14 @@ export default function ListLayoutWithTags({
   return (
     <>
       <div>
-        <div className="pb-6 pt-6">
-          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:hidden sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
-            {title}
-          </h1>
-        </div>
-        <div className="flex sm:space-x-24">
+        {title && (
+          <div className="pb-6 pt-6">
+            <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:hidden sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
+              {title}
+            </h1>
+          </div>
+        )}
+        <div className=" flex space-x-0 sm:space-x-12 xl:space-x-24">
           <div className="hidden h-full max-h-screen min-w-[280px] max-w-[280px] flex-wrap overflow-auto rounded bg-gray-50 pt-5 shadow-md dark:bg-gray-900/70 dark:shadow-gray-800/40 sm:flex">
             <div className="w-full py-4 pl-6">
               {pathname.startsWith('/blog') ? (
@@ -118,47 +121,98 @@ export default function ListLayoutWithTags({
               </ul>
             </div>
           </div>
-          <div>
-            <ul>
-              {displayPosts.map((post) => {
-                const { path, date, title, summary, tags } = post
-                return (
-                  <li key={path} className="py-5">
-                    <article className="flex flex-col space-y-2 xl:space-y-0">
-                      <dl>
-                        <dt className="sr-only">Published on</dt>
-                        <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
-                          <time dateTime={date} suppressHydrationWarning>
-                            {formatDate(date, siteMetadata.locale)}
-                          </time>
-                        </dd>
-                      </dl>
-                      <div className="space-y-3">
-                        <div>
-                          <h2 className="text-2xl font-bold leading-8 tracking-tight">
-                            <Link href={`/${path}`} className="text-gray-900 dark:text-gray-100">
-                              {title}
-                            </Link>
-                          </h2>
-                          <div className="flex flex-wrap">
-                            {tags?.map((tag) => <Tag key={tag} text={tag} />)}
-                          </div>
-                        </div>
-                        <div className="prose max-w-none text-gray-500 dark:text-gray-400">
-                          {summary}
-                        </div>
-                      </div>
-                    </article>
-                  </li>
-                )
-              })}
-            </ul>
-            {pagination && pagination.totalPages > 1 && (
-              <Pagination currentPage={pagination.currentPage} totalPages={pagination.totalPages} />
-            )}
-          </div>
+          <ListLayoutBase posts={displayPosts} pagination={pagination} />
         </div>
       </div>
     </>
+  )
+}
+
+interface ListLayoutBaseProps extends ListLayoutProps {
+  readMore?: boolean
+  dateToSide?: boolean
+}
+
+export function ListLayoutBase({
+  posts,
+  pagination,
+  readMore = false,
+  dateToSide = false,
+}: ListLayoutBaseProps) {
+  return (
+    <div className="w-full">
+      <ul>
+        {posts.map((post) => {
+          const { path, date, title, summary, tags } = post
+          return (
+            <li key={path} className="py-3">
+              <article>
+                <div
+                  className={clsx({
+                    'space-y-2 xl:grid xl:grid-cols-4 xl:items-baseline xl:space-y-0':
+                      dateToSide === true,
+                    'pointer mb-1 flex flex-col space-y-2 transition-colors xl:space-y-0':
+                      dateToSide === false,
+                  })}
+                >
+                  {dateToSide && (
+                    <dl className="hidden xl:block">
+                      <dt className="sr-only">Published on</dt>
+                      <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
+                        <time dateTime={date} suppressHydrationWarning>
+                          {formatDate(date, siteMetadata.locale)}
+                        </time>
+                      </dd>
+                    </dl>
+                  )}
+                  <div className={clsx({ 'space-y-5 xl:col-span-3': dateToSide === true })}>
+                    <Link className="group" href={`/${path}`}>
+                      <div className="mb-2 rounded-lg border border-transparent p-2 group-hover:border-primary-400 group-hover:bg-primary-100 dark:hover:bg-primary-900">
+                        <dl className={clsx({ 'block xl:hidden': dateToSide, block: !dateToSide })}>
+                          <dt className="sr-only">Published on</dt>
+                          <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
+                            <time dateTime={date} suppressHydrationWarning>
+                              {formatDate(date, siteMetadata.locale)}
+                            </time>
+                          </dd>
+                        </dl>
+
+                        <div>
+                          <div>
+                            <h2 className="text-2xl font-bold leading-8 tracking-tight">
+                              <p className="text-gray-900 dark:text-gray-100">{title}</p>
+                            </h2>
+                          </div>
+                          <div className="prose max-w-none text-gray-500 dark:text-gray-400">
+                            {summary}
+                          </div>
+                          {readMore && (
+                            <div className="text-base font-medium leading-6">
+                              <Link
+                                href={`/blog/${slug}`}
+                                className="text-primary-500 group-hover:text-primary-600 dark:group-hover:text-primary-400"
+                                aria-label={`Read more: "${title}"`}
+                              >
+                                Read more &rarr;
+                              </Link>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </Link>
+                    <div className="flex flex-row flex-wrap gap-1">
+                      {tags?.map((tag) => <Tag key={tag} text={tag} />)}
+                    </div>
+                  </div>
+                </div>
+              </article>
+            </li>
+          )
+        })}
+      </ul>
+      {pagination && pagination.totalPages > 1 && (
+        <Pagination currentPage={pagination.currentPage} totalPages={pagination.totalPages} />
+      )}
+    </div>
   )
 }


### PR DESCRIPTION
## Overview

I wanted to have a bit more visual feedback when the user hovered on blog posts. I'm using these changes on my personal blog and though the template might benefit from them as well.

### Changes Overview

- Refactor `ListLayoutWithTags.tsx` to extract `Pagination` and the base configuration of list layout
- Create `Pagination` component from code within `ListLayoutWithTags.tsx`
- Create `ListLayoutBase` component from a combination of code from `ListLayoutWithTags.tsx` and `Main.tsx`
  - Create configuration options to match both stylings
- Update styling in `ListLayoutBase` to add hover effect on each blog entry
- Update styling in `Tag.tsx` to be displayed under each blog post

### Visual Changes
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4275067e-18e7-4013-8a62-c2a9b1bf7eb4" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/c89e3974-3850-4143-9a76-5a4722d65d8b" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/356124a0-da68-484a-b6e2-b0339ae7e835" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/097c0747-ff08-4023-9cf6-1247d44a9e14" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/6c413778-7223-4ea0-9e98-bb543a54dda1" />

### View a deployed version of the changes [here](https://tailwind-nextjs-starter-blog-nine.vercel.app/)
 - [/](https://tailwind-nextjs-starter-blog-nine.vercel.app/)
 - [/tags/[tag]](https://tailwind-nextjs-starter-blog-nine.vercel.app/tags/next-js)
 - [/blog/[post]](https://tailwind-nextjs-starter-blog-nine.vercel.app/blog/release-of-tailwind-nextjs-starter-blog-v2.0)

