### PR TITLE
Add Culture DevOps blog to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Internationalization support - [Template with i18n](https://tailwind-nextjs-star
 - [Engineering Notes](https://www.jonvet.com) - Jonas Vetterle Personal Website & Blog. I'm writing articles about software engineering that interest me, including AI and Quantum Computing
 - [Screenager.dev](https://screenager.vercel.app) - Personal Website as Portfolio & Blog. Documenting my learning journey and some guides.
 - [kezhenxu94's blog](https://kezhenxu94.me) - Blogging about dev, tips & tricks, tutorials and more.
+- [Culture DevOps](https://culturedevops.com/en) - Technical blog on DevOps practices and tools ([source code](https://github.com/CultureDevOps/blog)).
 
 Using the template? Feel free to create a PR and add your blog to this list.
 


### PR DESCRIPTION
This PR adds my blog, [Culture DevOps](https://culturedevops.com/en), to the list of projects using this template.
The blog focuses on DevOps practices and tools, sharing technical tips and insights.

The source code is available on GitHub: [Culture DevOps GitHub](https://github.com/CultureDevOps/blog).

Let me know if there’s anything else I should adjust.