### PR TITLE
fix: Add outline focus-visible styles for buttons, links

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -29,14 +29,14 @@ const Header = () => {
         </div>
       </Link>
       <div className="flex items-center space-x-4 leading-5 sm:space-x-6">
-        <div className="no-scrollbar hidden max-w-40 items-center space-x-4 overflow-x-auto sm:flex sm:space-x-6 md:max-w-72 lg:max-w-96">
+        <div className="no-scrollbar hidden max-w-40 items-center space-x-4 overflow-x-auto pr-2 sm:flex sm:space-x-6 md:max-w-72 lg:max-w-96">
           {headerNavLinks
             .filter((link) => link.href !== '/')
             .map((link) => (
               <Link
                 key={link.title}
                 href={link.href}
-                className="block font-medium text-gray-900 hover:text-primary-500 dark:text-gray-100 dark:hover:text-primary-400"
+                className="m-1 block font-medium text-gray-900 hover:text-primary-500 dark:text-gray-100 dark:hover:text-primary-400"
               >
                 {link.title}
               </Link>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -72,5 +72,20 @@ module.exports = {
       }),
     },
   },
-  plugins: [require('@tailwindcss/forms'), require('@tailwindcss/typography')],
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    ({ addBase, theme }) => {
+      addBase({
+        'a, button': {
+          outlineColor: theme('colors.primary.500'),
+          '&:focus-visible': {
+            outline: '2px solid',
+            borderRadius: theme('borderRadius.DEFAULT'),
+            outlineColor: theme('colors.primary.500'),
+          },
+        },
+      })
+    },
+  ],
 }


### PR DESCRIPTION
## Issue
When tabbing through links, focus ring for header nav links doesn't display a complete ring and has poor contrast.

## Changes

`tailwind.config.js`
 - Add base styles to `button` `link` in `focus-visible` state
   - Add outline style
   - Outline color set as primary color from tailwind config

`components/Header.tsx`
 - Add pr-2 to container, m-1 to links to ensure the outline has enough roomt to display completely.

[View deployed changes](https://tailwind-nextjs-starter-blog-trillium.vercel.app/)

<details><summary>Before</summary>

<img width="842" alt="image" src="https://github.com/user-attachments/assets/a9c5be54-7a10-4618-88de-bc7362d14de3" />

</details> 

<details><summary>After</summary>

<img width="842" alt="image" src="https://github.com/user-attachments/assets/7e64cd75-4e3d-41a2-97e5-dfdd97f6f57d" />

</details> 

Tested in (macOS):
 - Chrome
 - Firefox
 - Safari

---

### Notes
I had to push these changes with --no-verify due to husky failing pre-commit checks that are unrelated to the PR:

<img width="493" alt="image" src="https://github.com/user-attachments/assets/b7b618a0-c6e5-4bbd-8d05-ee50c2ff1b15" />

```
⚠ Running tasks for staged files...
  ❯ package.json — 2 files
    ❯ *.+(js|jsx|ts|tsx) — 1 file
      ✖ eslint --fix [KILLED]
    ❯ *.+(js|jsx|ts|tsx|json|css|md|mdx) — 1 file
      ✖ prettier --write [FAILED]
↓ Skipped because of errors from tasks.
↓ Skipped because of errors from tasks.
✔ Reverting to original state because of errors...
✔ Cleaning up temporary files...

✖ prettier --write:
[error] require() of ES Module /Users/trilliumsmith/code/trilliumsmith.com/fork/tailwind-nextjs-starter-blog/node_modules/prettier-plugin-tailwindcss/dist/index.mjs not supported.
[error] Instead change the require of /Users/trilliumsmith/code/trilliumsmith.com/fork/tailwind-nextjs-starter-blog/node_modules/prettier-plugin-tailwindcss/dist/index.mjs to a dynamic import() which is available in all CommonJS modules.

✖ eslint --fix failed without output (KILLED).
husky - pre-commit script failed (code 1)
```
