### PR TITLE
Tag Page Generation Patch

### DIFF
--- a/app/tags/[tag]/page/[page]/page.tsx
+++ b/app/tags/[tag]/page/[page]/page.tsx
@@ -11,10 +11,10 @@ export const generateStaticParams = async () => {
   const tagCounts = tagData as Record<string, number>
   return Object.keys(tagCounts).flatMap((tag) => {
     const postCount = tagCounts[tag]
-    const totalPages = Math.ceil(postCount / POSTS_PER_PAGE)
-    return Array.from({ length: totalPages - 1 }, (_, i) => ({
+    const totalPages = Math.max(1, Math.ceil(postCount / POSTS_PER_PAGE))
+    return Array.from({ length: totalPages }, (_, i) => ({
       tag: encodeURI(tag),
-      page: (i + 2).toString(),
+      page: (i + 1).toString(),
     }))
   })
 }


### PR DESCRIPTION
Currently when the generation for tag pagination happens, if the site is built using GitHub Pages it gives the following error: 
`[Error: Page "/tags/[tag]/page/[page]" is missing "generateStaticParams()" so it cannot be used with "output: export" config.]`
This only occurs if there isn't enough tags to generate a second page of any tag that already exists in the blog, such as if you only have one public blog page prepared.

My first workaround to this was to modify the tags of the only blog to repeat the placeholder tag 6 times, however when checking the code more the modifications made below worked, allowing GitHub Pages to be built even when there isn't enough tags for a second page and still having proper pagination when the second page does exist.