### PR TITLE
Add blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Internationalization support - [Template with i18n](https://tailwind-nextjs-star
 - [taitrd.com](https://taitrd.com) - Tai's personal dev blog, technologies and coding activity with Dynamodb practice ([source code](https://github.com/taitrd/taitrd)).
 - [Shelton's Blog](https://www.sheltonma.top) - Sharing insights on TypeScript full-stack development (Next.js, React, Hono, Supabase), web crawlers, and other cutting-edge technologies.
 - [Culture DevOps](https://culturedevops.com/en) - Technical blog on DevOps practices and tools ([source code](https://github.com/CultureDevOps/blog)).
+- [InnovateWire Blog](https://innovatewire.com) - A tech blog about software automation and automation tools ([Project Link](https://innovatewire.com))
 
 Using the template? Feel free to create a PR and add your blog to this list.
 


### PR DESCRIPTION
Add New Example Blog Link
Summary
This PR adds blog link as an example on the Tailwind Next.js Starter Blog.
