### PR TITLE
up next-themes for react 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "image-size": "1.0.0",
     "next": "15.1.4",
     "next-contentlayer2": "0.5.4",
-    "next-themes": "^0.3.0",
+    "next-themes": "^0.4.4",
     "pliny": "0.4.1",
     "postcss": "^8.4.24",
     "react": "19.0.0",


### PR DESCRIPTION
`next-themes` v0.3.0 is not compatible with react 19. Upping the version to v0.4.4 which is compatible.

![image](https://github.com/user-attachments/assets/3240491e-9418-46d7-a40d-b825f11e34fe)
