### PR TITLE
Fix for [ Server ] Error: Cannot read properties of undefined (readin…

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -45,7 +45,7 @@ export async function generateMetadata(props: {
   }
   const ogImages = imageList.map((img) => {
     return {
-      url: img.includes('http') ? img : siteMetadata.siteUrl + img,
+      url: img && img.includes('http') ? img : siteMetadata.siteUrl + img,
     }
   })
 


### PR DESCRIPTION
…g 'includes')

When creating a new blog post sometimes this error occurs 


`
[ Server ] Error: Cannot read properties of undefined (reading 'includes')
Unhandled Runtime Error

[ Server ] Error: Cannot read properties of undefined (reading 'includes')

eval
./app/blog/%5B...slug%5D/page.tsx
Module.generateMetadata
./app/blog/%5B...slug%5D/page.tsx

`