### PR TITLE
style: remove content from code pseudo-elements

### DIFF
--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -98,6 +98,12 @@
     }
     & :where(code):not(pre code) {
       color: var(--color-indigo-500);
+      &::before {
+        content: none;
+      }
+      &::after {
+        content: none;
+      }
     }
   }
 


### PR DESCRIPTION

This PR updates the `inline code` style. The default tailwind typography will add backticks `` ` `` around the code.

* The old style: 
    ![image](https://github.com/user-attachments/assets/58e5c436-4906-4f48-b3f1-54ae616f8ce9)


* The updated style removes the surrounding backticks `` ` `` 
    ![image](https://github.com/user-attachments/assets/15acb492-aa1c-4239-9702-71394ccf6e51)
