### PR TITLE
Fix for regex trialing slash if `trailingSlash: true`

### DIFF
--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -26,7 +26,7 @@ function Pagination({ totalPages, currentPage }: PaginationProps) {
   const lastSegment = segments[segments.length - 1]
   const basePath = pathname
     .replace(/^\//, '') // Remove leading slash
-    .replace(/\/page\/\d+$/, '') // Remove any trailing /page
+    .replace(/\/page\/\d+\/?$/, '') // Remove any trailing /page and optional trailing slash
   const prevPage = currentPage - 1 > 0
   const nextPage = currentPage + 1 <= totalPages
 

--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -26,7 +26,8 @@ function Pagination({ totalPages, currentPage }: PaginationProps) {
   const lastSegment = segments[segments.length - 1]
   const basePath = pathname
     .replace(/^\//, '') // Remove leading slash
-    .replace(/\/page\/\d+\/?$/, '') // Remove any trailing /page and optional trailing slash
+    .replace(/\/page\/\d+\/?$/, '') // Remove any trailing /page
+    .replace(/\/$/, '') // Remove trailing slash
   const prevPage = currentPage - 1 > 0
   const nextPage = currentPage + 1 <= totalPages
 

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -27,9 +27,7 @@ function Pagination({ totalPages, currentPage }: PaginationProps) {
   const lastSegment = segments[segments.length - 1]
   const basePath = pathname
     .replace(/^\//, '') // Remove leading slash
-    .replace(/\/page\/\d+$/, '') // Remove any trailing /page
-  console.log(pathname)
-  console.log(basePath)
+    .replace(/\/page\/\d+\/?$/, '') // Remove any trailing /page and optional trailing slash
   const prevPage = currentPage - 1 > 0
   const nextPage = currentPage + 1 <= totalPages
 

--- a/layouts/ListLayoutWithTags.tsx
+++ b/layouts/ListLayoutWithTags.tsx
@@ -27,7 +27,8 @@ function Pagination({ totalPages, currentPage }: PaginationProps) {
   const lastSegment = segments[segments.length - 1]
   const basePath = pathname
     .replace(/^\//, '') // Remove leading slash
-    .replace(/\/page\/\d+\/?$/, '') // Remove any trailing /page and optional trailing slash
+    .replace(/\/page\/\d+\/?$/, '') // Remove any trailing /page
+    .replace(/\/$/, '') // Remove trailing slash
   const prevPage = currentPage - 1 > 0
   const nextPage = currentPage + 1 <= totalPages
 

--- a/next.config.js
+++ b/next.config.js
@@ -67,6 +67,7 @@ module.exports = () => {
     output,
     basePath,
     reactStrictMode: true,
+    trailingSlash: false,
     pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
     eslint: {
       dirs: ['app', 'components', 'layouts', 'scripts'],


### PR DESCRIPTION
Fixes #1137

This PR fixes the issue on the regex in list layouts for removing the trailing slash used in pagination.

If `trailingSlash: true` in `next.config.js`, this will now remove the trailing slashes.

Also removed some `console.log()` messages.