### PR TITLE
Remove outdated outline style

### DIFF
--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -76,7 +76,7 @@ const MobileNav = () => {
                   <Link
                     key={link.title}
                     href={link.href}
-                    className="hover:text-primary-500 dark:hover:text-primary-400 mb-4 py-2 pr-4 text-2xl font-bold tracking-widest text-gray-900 outline outline-0 dark:text-gray-100"
+                    className="hover:text-primary-500 dark:hover:text-primary-400 mb-4 py-2 pr-4 text-2xl font-bold tracking-widest text-gray-900 outline-0 dark:text-gray-100"
                     onClick={onToggleNav}
                   >
                     {link.title}


### PR DESCRIPTION
`outline` no longer needed as per https://tailwindcss.com/docs/upgrade-guide#renamed-outline-utility. Fix #1159 