### PR TITLE
A bug occurs when a tag is registered in Korean.

### DIFF
--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -37,7 +37,7 @@ export const generateStaticParams = async () => {
 export default async function TagPage(props: { params: Promise<{ tag: string }> }) {
   const params = await props.params
   const tag = decodeURI(params.tag)
-  const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
+  const title = decodeURI(tag[0].toUpperCase() + tag.split(' ').join('-').slice(1))
   const filteredPosts = allCoreContent(
     sortPosts(
       allBlogs.filter((post) => post.tags && post.tags.map((t) => slug(t)).includes(decodeURI(tag)))

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata(props: {
   const params = await props.params
   const tag = decodeURI(params.tag)
   return genPageMetadata({
-    title: tag,
+    title: decodeURI(tag),
     description: `${siteMetadata.title} ${tag} tagged content`,
     alternates: {
       canonical: './',

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -39,7 +39,9 @@ export default async function TagPage(props: { params: Promise<{ tag: string }> 
   const tag = decodeURI(params.tag)
   const title = tag[0].toUpperCase() + tag.split(' ').join('-').slice(1)
   const filteredPosts = allCoreContent(
-    sortPosts(allBlogs.filter((post) => post.tags && post.tags.map((t) => slug(t)).includes(tag)))
+    sortPosts(
+      allBlogs.filter((post) => post.tags && post.tags.map((t) => slug(t)).includes(decodeURI(tag)))
+    )
   )
   const totalPages = Math.ceil(filteredPosts.length / POSTS_PER_PAGE)
   const initialDisplayPosts = filteredPosts.slice(0, POSTS_PER_PAGE)


### PR DESCRIPTION

This is the fix related to issues that occur when using Korean characters as tag names.

1. Fixed the issue where posts were not displayed properly when selecting a tag written in Korean.
2. Fixed the issue where the browser title appeared as encoded text when selecting a Korean tag.
3. Fixed the issue where the header title appeared as encoded text in mobile browsers when selecting a Korean tag.

These issues do not occur when using English tags, but when using Korean tags, the screen appears as shown in the image below.

> Browser title
<img width="237" height="35" alt="image" src="https://github.com/user-attachments/assets/68dca03b-2cef-40c5-91a2-d9f850db8490" />

<br/><br/>


> The difference between tapping a Korean tag and an English tag
<img width="1171" height="597" alt="image" src="https://github.com/user-attachments/assets/9380f3ef-0e46-483a-a67b-98048a454a97" />
<img width="1035" height="546" alt="image" src="https://github.com/user-attachments/assets/1c625ff4-fc31-499a-a9c7-6e5f3304cd46" />

<br/><br/>

> When a tag is tapped in a mobile browser
<img width="372" height="151" alt="image" src="https://github.com/user-attachments/assets/8e0793dc-2d9c-45fe-b646-2c57fa553f76" />

