### PR TITLE
feat: added Tailwind styles to theme switcher buttons

### DIFF
--- a/components/ThemeSwitch.tsx
+++ b/components/ThemeSwitch.tsx
@@ -78,14 +78,14 @@ const ThemeSwitch = () => {
           leaveFrom="transform opacity-100 scale-100"
           leaveTo="transform opacity-0 scale-95"
         >
-          <MenuItems className="ring-opacity-5 absolute right-0 z-50 mt-2 w-32 origin-top-right divide-y divide-gray-100 rounded-md bg-white ring-1 shadow-lg ring-black focus:outline-hidden dark:bg-gray-800">
+          <MenuItems className="ring-opacity-5 absolute right-0 z-50 mt-2 w-32 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black focus:outline-hidden dark:bg-gray-800">
             <RadioGroup value={theme} onChange={setTheme}>
               <div className="p-1">
                 <Radio value="light">
                   <MenuItem>
                     {({ focus }) => (
                       <button
-                        className={`${focus ? 'bg-primary-600 text-white' : ''} group flex w-full items-center rounded-md px-2 py-2 text-sm`}
+                        className={`${focus ? 'bg-yellow-300 text-black' : ''} group flex w-full items-center rounded-md px-2 py-2 text-sm`}
                       >
                         <div className="mr-2">
                           <Sun />
@@ -100,7 +100,7 @@ const ThemeSwitch = () => {
                     {({ focus }) => (
                       <button
                         className={`${
-                          focus ? 'bg-primary-600 text-white' : ''
+                          focus ? 'bg-gray-800 text-white' : ''
                         } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
                       >
                         <div className="mr-2">
@@ -116,7 +116,9 @@ const ThemeSwitch = () => {
                     {({ focus }) => (
                       <button
                         className={`${
-                          focus ? 'bg-primary-600 text-white' : ''
+                          focus
+                            ? 'bg-gradient-to-r from-gray-300 via-white to-gray-300 text-black'
+                            : ''
                         } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
                       >
                         <div className="mr-2">


### PR DESCRIPTION
✨ Improved Theme Switch Button Styling for Light, Dark, and System Modes

This PR enhances the UI of the theme switcher by updating the visual styling of each mode’s button in `ThemeSwitch.tsx`.

🌞 Light Mode: The light theme button now uses a bright yellow background (`bg-yellow-300`) with black text for better visibility and a cheerful look.

🌙 Dark Mode: The dark theme button now appears with a deep gray background (`bg-gray-800`) and white text, visually aligning with the dark theme’s aesthetic and making it easy to distinguish.

🖥️ System Mode: A subtle gradient (`from-gray-300 via-white to-gray-300`) now highlights the system mode, giving it a clean, neutral presence that reflects its adaptive nature.

All three buttons maintain consistent padding, rounded corners, and flex styling (`group flex w-full items-center rounded-md px-2 py-2 text-sm`) for a unified layout experience.

🎯 Purpose:
These changes aim to:
- Make each mode more immediately recognizable through distinct styles
- Improve the user interface without altering any underlying functionality
- Preserve accessibility and readability

This is a purely visual improvement and introduces **no breaking changes**. Happy to iterate further with hover effects or transitions in future PRs if needed! 🙌