### PR TITLE
add additional metadata for canonical url to properly render

### DIFF
--- a/app/blog/[...slug]/page.tsx
+++ b/app/blog/[...slug]/page.tsx
@@ -52,6 +52,9 @@ export async function generateMetadata(props: {
   return {
     title: post.title,
     description: post.summary,
+    alternates: {
+      canonical: post.canonicalUrl || `${siteMetadata.siteUrl}/${post.slug}`,
+    },
     openGraph: {
       title: post.title,
       description: post.summary,
@@ -60,7 +63,7 @@ export async function generateMetadata(props: {
       type: 'article',
       publishedTime: publishedAt,
       modifiedTime: modifiedAt,
-      url: './',
+      url: post.canonicalUrl || `${siteMetadata.siteUrl}/${post.slug}`,
       images: ogImages,
       authors: authors.length > 0 ? authors : [siteMetadata.author],
     },

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -122,7 +122,7 @@ export const Blog = defineDocumentType(() => ({
         dateModified: doc.lastmod || doc.date,
         description: doc.summary,
         image: doc.images ? doc.images[0] : siteMetadata.socialBanner,
-        url: `${siteMetadata.siteUrl}/${doc._raw.flattenedPath}`,
+        url: doc.canonicalUrl || `${siteMetadata.siteUrl}/${doc._raw.flattenedPath}`,
       }),
     },
   },


### PR DESCRIPTION
Fixes #1192 

The canonical url wasn't properly making it's way through all the config and metadata. This adds it in the missing places.