### PR TITLE
URGENT: Upgrade required for React CVE-2025-55182

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gray-matter": "^4.0.2",
     "hast-util-from-html-isomorphic": "^2.0.0",
     "image-size": "2.0.1",
-    "next": "15.2.4",
+    "next": "15.2.6",
     "next-contentlayer2": "0.5.5",
     "next-themes": "^0.4.6",
     "pliny": "0.4.1",


### PR DESCRIPTION
This repository is listed on [Vercel Templates](https://vercel.com/templates). 

It uses a version of Next.js that is vulnerable to [React2Shell](https://vercel.com/kb/bulletin/react2shell). This PR upgrades the template to the nearest patched version.

We have temporarily disabled the ability for developers to deploy this template. 

**Action required**

Please review the changes and run a quick test. If everything looks correct, you can merge this PR.
If you prefer to upgrade manually, feel free to close this and apply your own fix.

Thank you.